### PR TITLE
Improve Makefile.toml tasks

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -32,7 +32,7 @@ jobs:
           profile: minimal
           toolchain: ${{ matrix.rust }}
           override: true
-          components: rustfmt
+          components: rustfmt, clippy
       - uses: Swatinem/rust-cache@v1
       - name: Flatbuffers binary cache
         id: flatbuffers-cache
@@ -53,28 +53,3 @@ jobs:
         with:
           command: make
           args: full-test
-
-  Lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v1
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-          components: rustfmt, clippy
-      - uses: Swatinem/rust-cache@v1
-      - name: Flatbuffers binary cache
-        id: flatbuffers-cache
-        uses: actions/cache@v2
-        with:
-          path: ~/flatc
-          key: flatbuffers-${{ runner.os }}
-      - name: Install flatbuffers
-        if: steps.flatbuffers-cache.outputs.cache-hit != 'true'
-        run: .github/workflows/build_flatbuffers.sh
-      - name: Copy flatbuffers binary to /usr/bin
-        run: sudo cp ~/flatc /usr/local/bin/
-      - run: cargo fmt --all -- --check
-      - run: cargo clippy --all-targets -- -D warnings

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -52,11 +52,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: make
-          args: test
-      - uses: actions-rs/cargo@v1
-        with:
-          command: make
-          args: cli-test
+          args: full-test
 
   Lint:
     runs-on: ubuntu-latest

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -72,10 +72,34 @@ script = '''
     fi
 '''
 
-[tasks.commit-check]
-dependencies = ["cli-test"]
+[tasks.lint]
 script = '''
-cargo fmt --all -- --check
-cargo clippy --all-targets -- -D warnings
-cargo test
+    cargo fmt --all -- --check
+    cargo clippy --all-targets -- -D warnings
 '''
+
+[tasks.commit-check]
+script = '''
+    uncommited_changes=$(git status --porcelain=v1 --untracked-files=no 2>/dev/null | wc -l)
+    if [ $uncommited_changes -gt 0 ]; then
+        echo "commit-check failed because of unstaged changes:"
+        git status
+        exit 1
+    fi
+'''
+
+[tasks.regenerate-examples]
+dependencies = ["build"]
+script = '''
+    target/debug/planus rust -o examples/rust/src/monster_generated.rs examples/rust/monster.fbs
+'''
+
+[tasks.full-test]
+dependencies = [
+    "lint",
+    "regenerate-examples",
+    # Check that all examples are up to date
+    "commit-check",
+    "test",
+    "cli-test",
+]

--- a/planus-cli/src/lexer/text_lexer.rs
+++ b/planus-cli/src/lexer/text_lexer.rs
@@ -6,6 +6,7 @@ use logos::Logos;
 use crate::error::LexicalError;
 
 #[derive(Logos, Debug, PartialEq)]
+#[allow(clippy::enum_variant_names)]
 pub(crate) enum Text {
     #[error]
     Error,


### PR DESCRIPTION
Split up some tasks in Makefile.toml so we can get a faster feedback loop while developing

Also add a task to regenerate example files, which fixes #53 