### PR TITLE
Add generate-completions command to planus-cli

### DIFF
--- a/planus-cli/Cargo.toml
+++ b/planus-cli/Cargo.toml
@@ -17,6 +17,7 @@ askama = "0.11"
 atty = "0.2.14"
 bitflags = "1.2.1"
 clap = { version = "3.0.5", features = ["derive"] }
+clap_complete = "3.0.6"
 codespan = "0.11.1"
 codespan-reporting = "0.11.1"
 derive_more = "0.99.14"
@@ -31,6 +32,7 @@ thiserror = "1.0.24"
 vec_map = "0.8.2"
 
 [build-dependencies]
+clap = "3.0.14"
 derive_more = "0.99.14"
 lalrpop = "0.19.5"
 

--- a/planus-cli/Cargo.toml
+++ b/planus-cli/Cargo.toml
@@ -32,7 +32,6 @@ thiserror = "1.0.24"
 vec_map = "0.8.2"
 
 [build-dependencies]
-clap = "3.0.14"
 derive_more = "0.99.14"
 lalrpop = "0.19.5"
 

--- a/planus-cli/src/app/check.rs
+++ b/planus-cli/src/app/check.rs
@@ -1,12 +1,15 @@
+use std::path::PathBuf;
+
 use anyhow::Result;
 
 use crate::{ast_map::AstMap, ctx::Ctx, intermediate_language::translation::Translator};
-use clap::StructOpt;
+use clap::{Parser, ValueHint};
 
-/// Checks validity of files
-#[derive(StructOpt)]
+/// Check validity of .fbs files
+#[derive(Parser)]
 pub struct Command {
-    files: Vec<String>,
+    #[clap(value_hint = ValueHint::FilePath)]
+    files: Vec<PathBuf>,
 }
 
 impl Command {

--- a/planus-cli/src/app/format.rs
+++ b/planus-cli/src/app/format.rs
@@ -1,15 +1,18 @@
+use std::path::PathBuf;
+
 use anyhow::Result;
 
 use crate::ctx::Ctx;
-use clap::StructOpt;
+use clap::{Parser, ValueHint};
 
-// Formats .fbs files
-#[derive(StructOpt)]
+/// Format .fbs files
+#[derive(Parser)]
 pub struct Command {
-    file: String,
+    #[clap(value_hint = ValueHint::FilePath)]
+    file: PathBuf,
 
     /// Try to generate output even if the input has errors
-    #[structopt(long)]
+    #[clap(long)]
     ignore_errors: bool,
 }
 

--- a/planus-cli/src/app/gen_completions.rs
+++ b/planus-cli/src/app/gen_completions.rs
@@ -1,0 +1,22 @@
+use clap::{AppSettings, IntoApp, Parser};
+use clap_complete::{generate, Shell};
+
+/// Generate shell completion scripts
+#[derive(Parser)]
+#[clap(setting = AppSettings::ArgRequiredElseHelp)]
+pub struct Command {
+    /// Which shell to generate completions for
+    #[clap(arg_enum)]
+    shell: Shell,
+}
+
+impl Command {
+    pub fn run(self, _options: super::AppOptions) {
+        generate(
+            self.shell,
+            &mut super::App::into_app(),
+            "planus",
+            &mut std::io::stdout(),
+        );
+    }
+}

--- a/planus-cli/src/app/mod.rs
+++ b/planus-cli/src/app/mod.rs
@@ -1,10 +1,11 @@
 mod check;
 mod format;
+mod gen_completions;
 mod rust;
 
-use clap::StructOpt;
+use clap::Parser;
 
-#[derive(StructOpt)]
+#[derive(Parser)]
 pub struct App {
     #[clap(flatten)]
     app_options: AppOptions,
@@ -13,14 +14,15 @@ pub struct App {
     command: Command,
 }
 
-#[derive(StructOpt)]
+#[derive(Parser)]
 pub enum Command {
     Rust(rust::Command),
     Format(format::Command),
     Check(check::Command),
+    GenerateCompletions(gen_completions::Command),
 }
 
-#[derive(Default, StructOpt)]
+#[derive(Default, Parser)]
 pub struct AppOptions {}
 
 impl App {
@@ -29,6 +31,7 @@ impl App {
             Command::Rust(command) => command.run(self.app_options)?,
             Command::Format(command) => command.run(self.app_options)?,
             Command::Check(command) => command.run(self.app_options)?,
+            Command::GenerateCompletions(command) => command.run(self.app_options),
         }
         Ok(())
     }

--- a/planus-cli/src/app/rust.rs
+++ b/planus-cli/src/app/rust.rs
@@ -14,7 +14,7 @@ pub struct Command {
     /// Output file
     #[clap(short = 'o')]
     #[clap(value_hint = ValueHint::AnyPath)]
-    output_filename: String,
+    output_filename: PathBuf,
 }
 
 impl Command {

--- a/planus-cli/src/app/rust.rs
+++ b/planus-cli/src/app/rust.rs
@@ -1,15 +1,19 @@
+use std::path::PathBuf;
+
 use anyhow::Result;
 
 use crate::codegen::rust::generate_code;
-use clap::StructOpt;
+use clap::{Parser, ValueHint};
 
-/// Generates rust code
-#[derive(StructOpt)]
+/// Generate rust code
+#[derive(Parser)]
 pub struct Command {
-    files: Vec<String>,
+    #[clap(value_hint = ValueHint::FilePath)]
+    files: Vec<PathBuf>,
 
     /// Output file
-    #[structopt(short = 'o')]
+    #[clap(short = 'o')]
+    #[clap(value_hint = ValueHint::AnyPath)]
     output_filename: String,
 }
 

--- a/planus-cli/src/codegen/rust/mod.rs
+++ b/planus-cli/src/codegen/rust/mod.rs
@@ -907,9 +907,9 @@ pub fn format_file<P: AsRef<Path>>(path: P) -> std::io::Result<()> {
     Ok(())
 }
 
-pub fn generate_code<P: AsRef<Path>>(
-    input_files: &[P],
-    output_filename: &str,
+pub fn generate_code(
+    input_files: &[impl AsRef<Path>],
+    output_filename: impl AsRef<Path>,
 ) -> anyhow::Result<()> {
     let mut ctx = Ctx::default();
     let declarations = crate::intermediate_language::translate_files(&mut ctx, input_files);


### PR DESCRIPTION
Fixes #17.

The biggest missing limitation is that the commands that specifically need .fbs files doesn't complete to only those. It might be possible to hack it on, but otherwise it's blocked on https://github.com/clap-rs/clap/issues/1232