### PR TITLE
Add license files to array-init-cursor and planus crates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (they are enabled by default)
 - \[Rust\]: Bump the Minimum Support Rust Version (MSRV) to 1.61.0.
 - Update the `README` with information about our Discord server.
+- \[Rust\]: Add license files to crates
 
 ## [0.3.1] - 2022-06-15
 ### Added

--- a/array-init-cursor/LICENSE-APACHE
+++ b/array-init-cursor/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/array-init-cursor/LICENSE-MIT
+++ b/array-init-cursor/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/planus-cli/LICENSE-APACHE
+++ b/planus-cli/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/planus-cli/LICENSE-MIT
+++ b/planus-cli/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/planus/LICENSE-APACHE
+++ b/planus/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/planus/LICENSE-MIT
+++ b/planus/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT


### PR DESCRIPTION
Hi, thanks for this library! This PR symlinks the license files so they're included in the published `array-init-cursor` crate (could also copy if it that's better).

Edit: Sorry for all the noise - just noticed they're missing from the `planus` crate as well.