### PR TITLE
Fix typos and bad docstring output for unions

### DIFF
--- a/crates/planus-translation/src/ast_convert.rs
+++ b/crates/planus-translation/src/ast_convert.rs
@@ -907,10 +907,8 @@ impl<'ctx> CstConverter<'ctx> {
             // TODO: figure out if we should keep maintaining that entire pretty printer or do something simpler
             let mut printer = PrettyPrinter::new(&mut type_name, "");
             printer.write_type(&variant.type_).unwrap();
-            let default_docstring = format!(
-                "The variant of type `{}` in the union `{}`",
-                type_name, parent_ident
-            );
+            let default_docstring =
+                format!("The variant of type `{type_name}` in the union `{parent_ident}`",);
             docstrings =
                 self.convert_docstrings(type_metas.next().unwrap(), default_docstring, None);
         }

--- a/crates/planus-translation/src/ast_convert.rs
+++ b/crates/planus-translation/src/ast_convert.rs
@@ -6,7 +6,7 @@ use indexmap::{map::Entry, IndexMap};
 use planus_lexer::{Comment, CommentKind, TokenMetadata};
 use planus_types::{ast::*, cst};
 
-use crate::{ctx::Ctx, error::ErrorKind};
+use crate::{ctx::Ctx, error::ErrorKind, pretty_print::PrettyPrinter};
 
 struct CstConverter<'ctx> {
     pub schema: Schema,
@@ -638,7 +638,7 @@ impl<'ctx> CstConverter<'ctx> {
         is_table: bool,
     ) -> StructField {
         let default_docstring = format!(
-            "The field `{}` in on the {} `{}`",
+            "The field `{}` in the {} `{}`",
             field.ident.ident,
             if is_table { "table" } else { "struct" },
             parent_ident
@@ -776,7 +776,7 @@ impl<'ctx> CstConverter<'ctx> {
         parent_ident: &str,
     ) -> EnumVariant {
         let default_docstring = format!(
-            "The variant `{}` in on the enum `{}`",
+            "The variant `{}` in the enum `{}`",
             variant.ident.ident, parent_ident
         );
         let docstrings =
@@ -897,16 +897,19 @@ impl<'ctx> CstConverter<'ctx> {
         let docstrings;
         if let Some((name, colon)) = &variant.name {
             let default_docstring = format!(
-                "The variant `{}` in on the union `{}`",
+                "The variant `{}` in the union `{}`",
                 name.ident, parent_ident
             );
             docstrings = self.convert_docstrings(&name.token_metadata, default_docstring, None);
             self.handle_invalid_docstrings(&colon.token_metadata);
         } else {
-            // TODO: This is very bad documentation
+            let mut type_name = String::new();
+            // TODO: figure out if we should keep maintaining that entire pretty printer or do something simpler
+            let mut printer = PrettyPrinter::new(&mut type_name, "");
+            printer.write_type(&variant.type_).unwrap();
             let default_docstring = format!(
-                "The variant of type `{:?}` in on the union `{}`",
-                variant.type_.kind, parent_ident
+                "The variant of type `{}` in the union `{}`",
+                type_name, parent_ident
             );
             docstrings =
                 self.convert_docstrings(type_metas.next().unwrap(), default_docstring, None);
@@ -993,7 +996,7 @@ impl<'ctx> CstConverter<'ctx> {
 
     fn convert_rpc_method(&mut self, method: &cst::RpcMethod<'_>, parent_ident: &str) -> RpcMethod {
         let default_docstring = format!(
-            "The method `{}` in on the service `{}`",
+            "The method `{}` on the service `{}`",
             method.ident.ident, parent_ident
         );
         let docstrings =

--- a/crates/planus-translation/src/pretty_print.rs
+++ b/crates/planus-translation/src/pretty_print.rs
@@ -22,6 +22,14 @@ pub struct PrettyPrinter<'writer, 'src, T> {
 }
 
 impl<'writer, 'src, T: std::fmt::Write> PrettyPrinter<'writer, 'src, T> {
+    pub fn new(writer: &'writer mut T, source: &'src str) -> Self {
+        Self {
+            is_at_new_paragraph: true,
+            writer,
+            source,
+        }
+    }
+
     fn write_standalone_comment(
         &mut self,
         indent: bool,
@@ -588,7 +596,7 @@ impl<'writer, 'src, T: std::fmt::Write> PrettyPrinter<'writer, 'src, T> {
         Ok(())
     }
 
-    fn write_type(&mut self, decl: &Type<'_>) -> Result<(), std::fmt::Error> {
+    pub fn write_type(&mut self, decl: &Type<'_>) -> Result<(), std::fmt::Error> {
         match &decl.kind {
             cst::TypeKind::Vector(typ) => {
                 self.write_str("[")?;
@@ -670,11 +678,7 @@ pub fn pretty_print<W: std::fmt::Write>(
     schema: &Schema<'_>,
     writer: &mut W,
 ) -> std::fmt::Result {
-    let mut printer = PrettyPrinter {
-        is_at_new_paragraph: true,
-        writer,
-        source,
-    };
+    let mut printer = PrettyPrinter::new(writer, source);
 
     let mut last_declaration_requires_paragraph = false;
     for decl in &schema.declarations {


### PR DESCRIPTION
Uses the CST pretty printer for now in a kinda ugly way, until we get either an AST one or a better system for formatting types. I tested locally, but we don't have any real tests for it because everything in the monster example has docstrings, so it doesn't use any of the default ones. We should either modify it to do so, add a separate test, or always include the default docstring as I believe we talked about.

**Checklist**
- [X] Updated CHANGELOG.md with relevant changes
- [ ] Added tests for any new/fixed functionality
- [X] Added/updated documentation for new/changed code
- [X] Checked that README.md still makes sense (and updated it if necessary)
