### PR TITLE
Bump clap to v4

### DIFF
--- a/crates/planus-cli/Cargo.toml
+++ b/crates/planus-cli/Cargo.toml
@@ -20,7 +20,7 @@ planus-translation = { version = "0.4.0", path = "../planus-translation" }
 planus-lexer = { version = "0.4.0", path = "../planus-lexer" }
 planus-types = { version = "0.4.0", path = "../planus-types" }
 planus-inspector = { version = "0.4.0", path = "../planus-inspector" }
-clap = { version = "3.2.25", features = ["derive", "deprecated"] }
-clap_complete = "3.2.5"
+clap = { version = "4.4.2", features = ["derive", "color"] }
+clap_complete = "4.4.1"
 codespan = "0.11.1"
 color-eyre = "0.6.2"

--- a/crates/planus-cli/src/app/gen_completions.rs
+++ b/crates/planus-cli/src/app/gen_completions.rs
@@ -1,6 +1,6 @@
 use std::process::ExitCode;
 
-use clap::{IntoApp, Parser};
+use clap::{CommandFactory, Parser};
 use clap_complete::{generate, Shell};
 use color_eyre::Result;
 
@@ -9,7 +9,7 @@ use color_eyre::Result;
 #[clap(arg_required_else_help = true)]
 pub struct Command {
     /// Which shell to generate completions for
-    #[clap(arg_enum)]
+    #[arg(value_enum)]
     shell: Shell,
 }
 

--- a/crates/planus-cli/src/app/mod.rs
+++ b/crates/planus-cli/src/app/mod.rs
@@ -7,10 +7,22 @@ mod view;
 
 use std::process::ExitCode;
 
-use clap::Parser;
+use clap::{
+    builder::{styling::AnsiColor, Styles},
+    Parser,
+};
 use color_eyre::Result;
 
+fn clap_v3_styling() -> Styles {
+    Styles::styled()
+        .header(AnsiColor::Yellow.on_default())
+        .usage(AnsiColor::Green.on_default())
+        .literal(AnsiColor::Green.on_default())
+        .placeholder(AnsiColor::Green.on_default())
+}
+
 #[derive(Parser)]
+#[command(styles = clap_v3_styling())]
 pub struct App {
     #[clap(flatten)]
     app_options: AppOptions,

--- a/crates/planus-cli/src/main.rs
+++ b/crates/planus-cli/src/main.rs
@@ -1,6 +1,6 @@
 use std::process::ExitCode;
 
-use clap::StructOpt;
+use clap::Parser;
 use color_eyre::Result;
 
 mod app;

--- a/crates/planus-inspector/Cargo.toml
+++ b/crates/planus-inspector/Cargo.toml
@@ -16,5 +16,4 @@ planus-translation = { version = "0.4.0", path = "../planus-translation" }
 tui = "0.19.0"
 crossterm = "0.25"
 color-eyre = "0.6.2"
-clap = { version = "3.2.10", features = ["derive", "deprecated"] }
 fuzzy-matcher = "0.3.7"

--- a/crates/planus-inspector/src/app.rs
+++ b/crates/planus-inspector/src/app.rs
@@ -1,11 +1,5 @@
-use std::{
-    io,
-    ops::DerefMut,
-    path::{Path, PathBuf},
-    process::ExitCode,
-};
+use std::{io, ops::DerefMut, path::Path, process::ExitCode};
 
-use clap::{Parser, ValueHint};
 use color_eyre::Result;
 use crossterm::{
     cursor::Show,
@@ -18,17 +12,6 @@ use planus_types::intermediate::{AbsolutePath, DeclarationIndex, DeclarationKind
 use tui::{backend::CrosstermBackend, Terminal};
 
 use crate::{run_inspector, Inspector};
-
-#[derive(Parser)]
-pub struct App {
-    #[clap(value_hint = ValueHint::FilePath)]
-    data_file: PathBuf,
-
-    root_type: String,
-
-    #[clap(value_hint = ValueHint::FilePath, required = true)]
-    schema_files: Vec<PathBuf>,
-}
 
 pub fn run_app(schema_file: &Path, root_type: &str, data_file: &Path) -> Result<ExitCode> {
     let buffer = std::fs::read(data_file)?;


### PR DESCRIPTION
Clap v4.4.1 reintroduced stable support for colors, so we can now upgrade.

**Checklist**
- [x] Updated CHANGELOG.md with relevant changes
- [x] Added tests for any new/fixed functionality
- [x] Added/updated documentation for new/changed code
- [x] Checked that README.md still makes sense (and updated it if necessary)