### PR TITLE
Make run_app in inspector take a slice instead of path

### DIFF
--- a/crates/planus-cli/src/app/view.rs
+++ b/crates/planus-cli/src/app/view.rs
@@ -17,6 +17,7 @@ pub struct Command {
 
 impl Command {
     pub fn run(self, _options: super::AppOptions) -> Result<ExitCode> {
-        planus_inspector::app::run_app(&self.schema_file, &self.root_type, &self.data_file)
+        let buffer = std::fs::read(&self.data_file)?;
+        planus_inspector::app::run_app(&self.schema_file, &self.root_type, &buffer)
     }
 }

--- a/crates/planus-inspector/src/app.rs
+++ b/crates/planus-inspector/src/app.rs
@@ -64,7 +64,7 @@ pub fn run_app(schema_file: &Path, root_type: &str, buffer: &[u8]) -> Result<Exi
     let inspector = Inspector::new(
         planus_buffer_inspection::InspectableFlatbuffer {
             declarations: &declarations,
-            buffer: &buffer,
+            buffer,
         },
         DeclarationIndex(root_table_index),
     );

--- a/crates/planus-inspector/src/app.rs
+++ b/crates/planus-inspector/src/app.rs
@@ -13,9 +13,7 @@ use tui::{backend::CrosstermBackend, Terminal};
 
 use crate::{run_inspector, Inspector};
 
-pub fn run_app(schema_file: &Path, root_type: &str, data_file: &Path) -> Result<ExitCode> {
-    let buffer = std::fs::read(data_file)?;
-
+pub fn run_app(schema_file: &Path, root_type: &str, buffer: &[u8]) -> Result<ExitCode> {
     let Some(declarations) = translate_files(&[schema_file]) else {
         return Ok(ExitCode::FAILURE);
     };


### PR DESCRIPTION
This is a much more ergonomic api when creating a custom loader, as the flatbuffer data might be offset, compressed, or otherwise not loadable from a path

**Checklist**
- [ ] Updated CHANGELOG.md with relevant changes
- [ ] Added tests for any new/fixed functionality
- [ ] Added/updated documentation for new/changed code
- [ ] Checked that README.md still makes sense (and updated it if necessary)
