### PR TITLE
Make it so `cargo test` works from the root

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -109,7 +109,7 @@ script = '''
         pushd $dir
         for std in "" "std"; do
             for cache in "" "vtable-cache string-cache bytes-cache"; do
-                cargo test --features "${std} ${cache}"
+                cargo test --no-default-features --features "${std} ${cache}"
             done
         done
         popd

--- a/test/rust-compat/Cargo.toml
+++ b/test/rust-compat/Cargo.toml
@@ -7,7 +7,7 @@ repository.workspace = true
 rust-version.workspace = true
 
 [features]
-default = []
+default = ["std", "vtable-cache", "string-cache", "bytes-cache"]
 std = ["planus/std", "serde/std"]
 vtable-cache = ["planus/vtable-cache"]
 string-cache = ["planus/string-cache"]
@@ -17,7 +17,10 @@ bytes-cache = ["planus/bytes-cache"]
 planus = { path = "../../crates/planus", default-features = false, features = [
   "extra-validation",
 ] }
-serde = { version = "1.0.163", default-features = false, features = ["derive", "alloc"] }
+serde = { version = "1.0.163", default-features = false, features = [
+  "derive",
+  "alloc",
+] }
 
 [build-dependencies]
 color-eyre = "0.6.2"

--- a/test/rust/Cargo.toml
+++ b/test/rust/Cargo.toml
@@ -8,7 +8,7 @@ build = "build.rs"
 rust-version.workspace = true
 
 [features]
-default = []
+default = ["std", "vtable-cache", "string-cache", "bytes-cache"]
 std = ["planus/std", "serde/std"]
 vtable-cache = ["planus/vtable-cache"]
 string-cache = ["planus/string-cache"]


### PR DESCRIPTION
We normally use `cargo make full-test`, but `cargo test` should also work.

**Checklist**
- [x] Updated CHANGELOG.md with relevant changes
- [x] Added tests for any new/fixed functionality
- [x] Added/updated documentation for new/changed code
- [x] Checked that README.md still makes sense (and updated it if necessary)
