### PR TITLE
Add an option to ignore docstring errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - \[Rust\]: Added `#[allow(dead_code)]` to the root of the generated rust code [#204](https://github.com/planus-org/planus/pull/204)
+- Added the option `ignore_docstring_errors` to the app. [#216](https://github.com/planus-org/planus/pull/216)
 
 ### Fixed
 

--- a/crates/planus-cli/src/app/check.rs
+++ b/crates/planus-cli/src/app/check.rs
@@ -2,7 +2,7 @@ use std::{path::PathBuf, process::ExitCode};
 
 use clap::{Parser, ValueHint};
 use color_eyre::Result;
-use planus_translation::translate_files;
+use planus_translation::translate_files_with_options;
 
 /// Check validity of .fbs files
 #[derive(Parser)]
@@ -12,8 +12,8 @@ pub struct Command {
 }
 
 impl Command {
-    pub fn run(self, _options: super::AppOptions) -> Result<ExitCode> {
-        if translate_files(&self.files).is_none() {
+    pub fn run(self, options: super::AppOptions) -> Result<ExitCode> {
+        if translate_files_with_options(&self.files, options.to_converter_options()).is_none() {
             Ok(ExitCode::FAILURE)
         } else {
             Ok(ExitCode::SUCCESS)

--- a/crates/planus-cli/src/app/dot.rs
+++ b/crates/planus-cli/src/app/dot.rs
@@ -3,7 +3,7 @@ use std::{io::Write, path::PathBuf, process::ExitCode};
 use clap::{Parser, ValueHint};
 use color_eyre::Result;
 use planus_codegen::generate_dot;
-use planus_translation::translate_files;
+use planus_translation::translate_files_with_options;
 
 /// Generate a dot graph
 #[derive(Parser)]
@@ -18,8 +18,10 @@ pub struct Command {
 }
 
 impl Command {
-    pub fn run(self, _options: super::AppOptions) -> Result<ExitCode> {
-        let Some(declarations) = translate_files(&self.files) else {
+    pub fn run(self, options: super::AppOptions) -> Result<ExitCode> {
+        let Some(declarations) =
+            translate_files_with_options(&self.files, options.to_converter_options())
+        else {
             return Ok(ExitCode::FAILURE);
         };
 

--- a/crates/planus-cli/src/app/mod.rs
+++ b/crates/planus-cli/src/app/mod.rs
@@ -12,6 +12,7 @@ use clap::{
     Parser,
 };
 use color_eyre::Result;
+use planus_translation::ConverterOptions;
 
 fn clap_v3_styling() -> Styles {
     Styles::styled()
@@ -42,7 +43,18 @@ pub enum Command {
 }
 
 #[derive(Default, Parser)]
-pub struct AppOptions {}
+pub struct AppOptions {
+    #[clap(long)]
+    pub ignore_docstring_errors: bool,
+}
+
+impl AppOptions {
+    pub fn to_converter_options(&self) -> ConverterOptions {
+        ConverterOptions {
+            ignore_docstring_errors: self.ignore_docstring_errors,
+        }
+    }
+}
 
 impl App {
     pub fn run(self) -> Result<ExitCode> {

--- a/crates/planus-cli/src/app/rust.rs
+++ b/crates/planus-cli/src/app/rust.rs
@@ -3,7 +3,7 @@ use std::{io::Write, path::PathBuf, process::ExitCode};
 use clap::{Parser, ValueHint};
 use color_eyre::Result;
 use planus_codegen::generate_rust;
-use planus_translation::translate_files;
+use planus_translation::translate_files_with_options;
 
 /// Generate rust code
 #[derive(Parser)]
@@ -18,8 +18,10 @@ pub struct Command {
 }
 
 impl Command {
-    pub fn run(self, _options: super::AppOptions) -> Result<ExitCode> {
-        let Some(declarations) = translate_files(&self.files) else {
+    pub fn run(self, options: super::AppOptions) -> Result<ExitCode> {
+        let Some(declarations) =
+            translate_files_with_options(&self.files, options.to_converter_options())
+        else {
             return Ok(ExitCode::FAILURE);
         };
 

--- a/crates/planus-cli/src/app/view.rs
+++ b/crates/planus-cli/src/app/view.rs
@@ -16,8 +16,13 @@ pub struct Command {
 }
 
 impl Command {
-    pub fn run(self, _options: super::AppOptions) -> Result<ExitCode> {
+    pub fn run(self, options: super::AppOptions) -> Result<ExitCode> {
         let buffer = std::fs::read(&self.data_file)?;
-        planus_inspector::app::run_app(&self.schema_file, &self.root_type, &buffer)
+        planus_inspector::app::run_app(
+            &self.schema_file,
+            &self.root_type,
+            &buffer,
+            options.to_converter_options(),
+        )
     }
 }

--- a/crates/planus-inspector/src/app.rs
+++ b/crates/planus-inspector/src/app.rs
@@ -7,14 +7,19 @@ use crossterm::{
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
 use fuzzy_matcher::FuzzyMatcher;
-use planus_translation::translate_files;
+use planus_translation::{translate_files_with_options, ConverterOptions};
 use planus_types::intermediate::{AbsolutePath, DeclarationIndex, DeclarationKind};
 use tui::{backend::CrosstermBackend, Terminal};
 
 use crate::{run_inspector, Inspector};
 
-pub fn run_app(schema_file: &Path, root_type: &str, buffer: &[u8]) -> Result<ExitCode> {
-    let Some(declarations) = translate_files(&[schema_file]) else {
+pub fn run_app(
+    schema_file: &Path,
+    root_type: &str,
+    buffer: &[u8],
+    converter_options: ConverterOptions,
+) -> Result<ExitCode> {
+    let Some(declarations) = translate_files_with_options(&[schema_file], converter_options) else {
         return Ok(ExitCode::FAILURE);
     };
 

--- a/crates/planus-translation/src/ast_convert.rs
+++ b/crates/planus-translation/src/ast_convert.rs
@@ -1256,14 +1256,12 @@ impl<'ctx> CstConverter<'ctx> {
                         span: comment.span,
                         value: comment.content.to_owned(),
                     });
-                } else {
-                    if !self.converter_options.ignore_docstring_errors {
-                        self.emit_error(
-                            ErrorKind::MISC_SEMANTIC_ERROR,
-                            [Label::primary(self.schema.file_id, comment.span)],
-                            Some("Inner doc comments are not meaningful here."),
-                        );
-                    }
+                } else if !self.converter_options.ignore_docstring_errors {
+                    self.emit_error(
+                        ErrorKind::MISC_SEMANTIC_ERROR,
+                        [Label::primary(self.schema.file_id, comment.span)],
+                        Some("Inner doc comments are not meaningful here."),
+                    );
                 }
             }
         }

--- a/crates/planus-translation/src/intermediate_language/mod.rs
+++ b/crates/planus-translation/src/intermediate_language/mod.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 
 use planus_types::intermediate::Declarations;
 
-use crate::ctx::Ctx;
+use crate::{ast_convert::ConverterOptions, ctx::Ctx};
 
 pub mod checks;
 pub mod translation;
@@ -10,8 +10,15 @@ pub mod translation;
 pub mod ast_map;
 
 pub fn translate_files(input_files: &[impl AsRef<Path>]) -> Option<Declarations> {
+    translate_files_with_options(input_files, Default::default())
+}
+
+pub fn translate_files_with_options(
+    input_files: &[impl AsRef<Path>],
+    converter_options: ConverterOptions,
+) -> Option<Declarations> {
     let mut ctx = Ctx::default();
-    let declarations = translate_files_with_context(&mut ctx, input_files);
+    let declarations = translate_files_with_context(&mut ctx, input_files, converter_options);
     if !ctx.has_errors() {
         Some(declarations)
     } else {
@@ -22,8 +29,9 @@ pub fn translate_files(input_files: &[impl AsRef<Path>]) -> Option<Declarations>
 fn translate_files_with_context<P: AsRef<Path>>(
     ctx: &mut crate::ctx::Ctx,
     input_files: &[P],
+    converter_options: ConverterOptions,
 ) -> Declarations {
-    let mut ast_map = ast_map::AstMap::default();
+    let mut ast_map = ast_map::AstMap::new_with_options(converter_options);
     for file in input_files {
         if let Some(file_id) = ctx.add_file(file, []) {
             ast_map.add_files_recursively(ctx, file_id);

--- a/crates/planus-translation/src/lib.rs
+++ b/crates/planus-translation/src/lib.rs
@@ -19,8 +19,9 @@ mod util;
 
 use std::path::Path;
 
+pub use ast_convert::ConverterOptions;
 pub use error::ErrorKind;
-pub use intermediate_language::translate_files;
+pub use intermediate_language::{translate_files, translate_files_with_options};
 
 pub fn format_file(path: &impl AsRef<Path>, ignore_errors: bool) -> Option<String> {
     let mut ctx = ctx::Ctx::default();


### PR DESCRIPTION
This implements the feature request in #215.

**Checklist**
- [x] Updated CHANGELOG.md with relevant changes
- [x] Added tests for any new/fixed functionality
- [x] Added/updated documentation for new/changed code
- [x] Checked that README.md still makes sense (and updated it if necessary)
