### PR TITLE
Use a github token when doing the automated lockfile updates

### DIFF
--- a/.github/workflows/lockfile-update.yml
+++ b/.github/workflows/lockfile-update.yml
@@ -26,6 +26,7 @@ jobs:
       - name: Create pull request
         uses: peter-evans/create-pull-request@v5
         with:
+          token: ${{ secrets.GH_TOKEN_FOR_UPDATES }}
           commit-message: Update lockfiles
           title: "[Automated] Update lockfiles"
           branch: automated/lockfile-update


### PR DESCRIPTION
The automatic pull request created by this workflow would not have CI running automatically. See for instance https://github.com/planus-org/planus/pull/223

Use a token to get around this problem.

**Checklist**
- [x] Updated CHANGELOG.md with relevant changes
- [x] Added tests for any new/fixed functionality
- [x] Added/updated documentation for new/changed code
- [x] Checked that README.md still makes sense (and updated it if necessary)