### PR TITLE
Replace ExampleWithDefault->Example2 in a few tests, because the Example type now also implements Default

### DIFF
--- a/test/rust/api_files/table_string.fbs
+++ b/test/rust/api_files/table_string.fbs
@@ -6,7 +6,7 @@ table Example {
   value_required: string (required);
 }
 
-table ExampleWithDefault {
+table Example2 {
   value: string;
   value_null: string = null;
   value_default_empty: string = "";

--- a/test/rust/api_files/table_string.rs
+++ b/test/rust/api_files/table_string.rs
@@ -21,23 +21,23 @@ assert_traits!(
     ExampleRef<'_>: Copy + Clone + Debug + !PartialEq + !PartialOrd + !Eq + !Ord + !Hash + !Default + {TryInto<Example>} + !{Into<Example>},
 );
 
-check_type!(ExampleWithDefault => value : Option<String>);
-check_type!(ExampleWithDefault => value_null : Option<String>);
-check_type!(ExampleWithDefault => value_default_empty : String);
-check_type!(ExampleWithDefault => value_default_test : String);
-check_type!(ExampleWithDefault => create(&mut planus::Builder, String, String, String, String) : planus::Offset<ExampleWithDefault>);
-check_type!(ExampleWithDefault => create(&mut planus::Builder, (), (), String, String) : planus::Offset<ExampleWithDefault>);
-check_type!(ExampleWithDefault => create(&mut planus::Builder, Option<String>, Option<String>, String, String) : planus::Offset<ExampleWithDefault>);
-check_type!(+['a, 'b, 'c, 'd] ExampleWithDefault => create(&mut planus::Builder, &'a str, &'b str, &'c str, &'d str) : planus::Offset<ExampleWithDefault>);
-check_type!(+['a, 'b, 'c, 'd] ExampleWithDefault => create(&mut planus::Builder, Option<&'a str>, Option<&'b str>, &'c str, &'d str) : planus::Offset<ExampleWithDefault>);
+check_type!(Example2 => value : Option<String>);
+check_type!(Example2 => value_null : Option<String>);
+check_type!(Example2 => value_default_empty : String);
+check_type!(Example2 => value_default_test : String);
+check_type!(Example2 => create(&mut planus::Builder, String, String, String, String) : planus::Offset<Example2>);
+check_type!(Example2 => create(&mut planus::Builder, (), (), String, String) : planus::Offset<Example2>);
+check_type!(Example2 => create(&mut planus::Builder, Option<String>, Option<String>, String, String) : planus::Offset<Example2>);
+check_type!(+['a, 'b, 'c, 'd] Example2 => create(&mut planus::Builder, &'a str, &'b str, &'c str, &'d str) : planus::Offset<Example2>);
+check_type!(+['a, 'b, 'c, 'd] Example2 => create(&mut planus::Builder, Option<&'a str>, Option<&'b str>, &'c str, &'d str) : planus::Offset<Example2>);
 
-check_type!(+['a] ExampleWithDefaultRef<'a> => &self.value() : planus::Result<Option<&'a str>>);
-check_type!(+['a] ExampleWithDefaultRef<'a> => &self.value_null() : planus::Result<Option<&'a str>>);
-check_type!(+['a] ExampleWithDefaultRef<'a> => &self.value_default_empty() : planus::Result<&'a str>);
-check_type!(+['a] ExampleWithDefaultRef<'a> => &self.value_default_test() : planus::Result<&'a str>);
-check_type!(+['a] ExampleWithDefaultRef<'a> => impl planus::ReadAsRoot<'a>);
+check_type!(+['a] Example2Ref<'a> => &self.value() : planus::Result<Option<&'a str>>);
+check_type!(+['a] Example2Ref<'a> => &self.value_null() : planus::Result<Option<&'a str>>);
+check_type!(+['a] Example2Ref<'a> => &self.value_default_empty() : planus::Result<&'a str>);
+check_type!(+['a] Example2Ref<'a> => &self.value_default_test() : planus::Result<&'a str>);
+check_type!(+['a] Example2Ref<'a> => impl planus::ReadAsRoot<'a>);
 
 assert_traits!(
-    ExampleWithDefault: !Copy + Clone + Debug + PartialEq + PartialOrd + Eq + Ord + Hash + Default,
-    ExampleWithDefaultRef<'_>: Copy + Clone + Debug + !PartialEq + !PartialOrd + !Eq + !Ord + !Hash + !Default + {TryInto<ExampleWithDefault>} + !{Into<ExampleWithDefault>},
+    Example2: !Copy + Clone + Debug + PartialEq + PartialOrd + Eq + Ord + Hash + Default,
+    Example2Ref<'_>: Copy + Clone + Debug + !PartialEq + !PartialOrd + !Eq + !Ord + !Hash + !Default + {TryInto<Example2>} + !{Into<Example2>},
 );

--- a/test/rust/api_files/table_vector_int8.fbs
+++ b/test/rust/api_files/table_vector_int8.fbs
@@ -5,7 +5,7 @@ table Example {
   value_required: [int8] (required);
 }
 
-table ExampleWithDefault {
+table Example2 {
   value: [int8];
   value_null: [int8] = null;
   value_default_empty: [int8] = [];

--- a/test/rust/api_files/table_vector_int8.rs
+++ b/test/rust/api_files/table_vector_int8.rs
@@ -19,21 +19,21 @@ assert_traits!(
     ExampleRef<'_>: Copy + Clone + Debug + !PartialEq + !PartialOrd + !Eq + !Ord + !Hash + !Default + {TryInto<Example>} + !{Into<Example>},
 );
 
-check_type!(ExampleWithDefault => value : Option<Vec<i8>>);
-check_type!(ExampleWithDefault => value_null : Option<Vec<i8>>);
-check_type!(ExampleWithDefault => value_default_empty : Vec<i8>);
-check_type!(ExampleWithDefault => create(&mut planus::Builder, Vec<i8>, Vec<i8>, Vec<i8>) : planus::Offset<ExampleWithDefault>);
-check_type!(ExampleWithDefault => create(&mut planus::Builder, (), (), Vec<i8>) : planus::Offset<ExampleWithDefault>);
-check_type!(ExampleWithDefault => create(&mut planus::Builder, Option<Vec<i8>>, Option<Vec<i8>>, Vec<i8>) : planus::Offset<ExampleWithDefault>);
-check_type!(+['a, 'b, 'c] ExampleWithDefault => create(&mut planus::Builder, &'a [i8], &'b [i8], &'c [i8]) : planus::Offset<ExampleWithDefault>);
-check_type!(+['a, 'b, 'c] ExampleWithDefault => create(&mut planus::Builder, Option<&'a [i8]>, Option<&'b [i8]>, &'c [i8]) : planus::Offset<ExampleWithDefault>);
+check_type!(Example2 => value : Option<Vec<i8>>);
+check_type!(Example2 => value_null : Option<Vec<i8>>);
+check_type!(Example2 => value_default_empty : Vec<i8>);
+check_type!(Example2 => create(&mut planus::Builder, Vec<i8>, Vec<i8>, Vec<i8>) : planus::Offset<Example2>);
+check_type!(Example2 => create(&mut planus::Builder, (), (), Vec<i8>) : planus::Offset<Example2>);
+check_type!(Example2 => create(&mut planus::Builder, Option<Vec<i8>>, Option<Vec<i8>>, Vec<i8>) : planus::Offset<Example2>);
+check_type!(+['a, 'b, 'c] Example2 => create(&mut planus::Builder, &'a [i8], &'b [i8], &'c [i8]) : planus::Offset<Example2>);
+check_type!(+['a, 'b, 'c] Example2 => create(&mut planus::Builder, Option<&'a [i8]>, Option<&'b [i8]>, &'c [i8]) : planus::Offset<Example2>);
 
-check_type!(+['a] ExampleWithDefaultRef<'a> => &self.value() : planus::Result<Option<&'a [i8]>>);
-check_type!(+['a] ExampleWithDefaultRef<'a> => &self.value_null() : planus::Result<Option<&'a [i8]>>);
-check_type!(+['a] ExampleWithDefaultRef<'a> => &self.value_default_empty() : planus::Result<&'a [i8]>);
-check_type!(+['a] ExampleWithDefaultRef<'a> => impl planus::ReadAsRoot<'a>);
+check_type!(+['a] Example2Ref<'a> => &self.value() : planus::Result<Option<&'a [i8]>>);
+check_type!(+['a] Example2Ref<'a> => &self.value_null() : planus::Result<Option<&'a [i8]>>);
+check_type!(+['a] Example2Ref<'a> => &self.value_default_empty() : planus::Result<&'a [i8]>);
+check_type!(+['a] Example2Ref<'a> => impl planus::ReadAsRoot<'a>);
 
 assert_traits!(
-    ExampleWithDefault: !Copy + Clone + Debug + PartialEq + PartialOrd + Eq + Ord + Hash + Default,
-    ExampleWithDefaultRef<'_>: Copy + Clone + Debug + !PartialEq + !PartialOrd + !Eq + !Ord + !Hash + !Default + {TryInto<ExampleWithDefault>} + !{Into<ExampleWithDefault>},
+    Example2: !Copy + Clone + Debug + PartialEq + PartialOrd + Eq + Ord + Hash + Default,
+    Example2Ref<'_>: Copy + Clone + Debug + !PartialEq + !PartialOrd + !Eq + !Ord + !Hash + !Default + {TryInto<Example2>} + !{Into<Example2>},
 );

--- a/test/rust/api_files/table_vector_uint8.fbs
+++ b/test/rust/api_files/table_vector_uint8.fbs
@@ -5,7 +5,7 @@ table Example {
   value_required: [uint8] (required);
 }
 
-table ExampleWithDefault {
+table Example2 {
   value: [uint8];
   value_null: [uint8] = null;
   value_default_empty: [uint8] = [];

--- a/test/rust/api_files/table_vector_uint8.rs
+++ b/test/rust/api_files/table_vector_uint8.rs
@@ -19,21 +19,21 @@ assert_traits!(
     ExampleRef<'_>: Copy + Clone + Debug + !PartialEq + !PartialOrd + !Eq + !Ord + !Hash + !Default + {TryInto<Example>} + !{Into<Example>},
 );
 
-check_type!(ExampleWithDefault => value : Option<Vec<u8>>);
-check_type!(ExampleWithDefault => value_null : Option<Vec<u8>>);
-check_type!(ExampleWithDefault => value_default_empty : Vec<u8>);
-check_type!(ExampleWithDefault => create(&mut planus::Builder, Vec<u8>, Vec<u8>, Vec<u8>) : planus::Offset<ExampleWithDefault>);
-check_type!(ExampleWithDefault => create(&mut planus::Builder, (), (), Vec<u8>) : planus::Offset<ExampleWithDefault>);
-check_type!(ExampleWithDefault => create(&mut planus::Builder, Option<Vec<u8>>, Option<Vec<u8>>, Vec<u8>) : planus::Offset<ExampleWithDefault>);
-check_type!(+['a, 'b, 'c] ExampleWithDefault => create(&mut planus::Builder, &'a [u8], &'b [u8], &'c [u8]) : planus::Offset<ExampleWithDefault>);
-check_type!(+['a, 'b, 'c] ExampleWithDefault => create(&mut planus::Builder, Option<&'a [u8]>, Option<&'b [u8]>, &'c [u8]) : planus::Offset<ExampleWithDefault>);
+check_type!(Example2 => value : Option<Vec<u8>>);
+check_type!(Example2 => value_null : Option<Vec<u8>>);
+check_type!(Example2 => value_default_empty : Vec<u8>);
+check_type!(Example2 => create(&mut planus::Builder, Vec<u8>, Vec<u8>, Vec<u8>) : planus::Offset<Example2>);
+check_type!(Example2 => create(&mut planus::Builder, (), (), Vec<u8>) : planus::Offset<Example2>);
+check_type!(Example2 => create(&mut planus::Builder, Option<Vec<u8>>, Option<Vec<u8>>, Vec<u8>) : planus::Offset<Example2>);
+check_type!(+['a, 'b, 'c] Example2 => create(&mut planus::Builder, &'a [u8], &'b [u8], &'c [u8]) : planus::Offset<Example2>);
+check_type!(+['a, 'b, 'c] Example2 => create(&mut planus::Builder, Option<&'a [u8]>, Option<&'b [u8]>, &'c [u8]) : planus::Offset<Example2>);
 
-check_type!(+['a] ExampleWithDefaultRef<'a> => &self.value() : planus::Result<Option<&'a [u8]>>);
-check_type!(+['a] ExampleWithDefaultRef<'a> => &self.value_null() : planus::Result<Option<&'a [u8]>>);
-check_type!(+['a] ExampleWithDefaultRef<'a> => &self.value_default_empty() : planus::Result<&'a [u8]>);
-check_type!(+['a] ExampleWithDefaultRef<'a> => impl planus::ReadAsRoot<'a>);
+check_type!(+['a] Example2Ref<'a> => &self.value() : planus::Result<Option<&'a [u8]>>);
+check_type!(+['a] Example2Ref<'a> => &self.value_null() : planus::Result<Option<&'a [u8]>>);
+check_type!(+['a] Example2Ref<'a> => &self.value_default_empty() : planus::Result<&'a [u8]>);
+check_type!(+['a] Example2Ref<'a> => impl planus::ReadAsRoot<'a>);
 
 assert_traits!(
-    ExampleWithDefault: !Copy + Clone + Debug + PartialEq + PartialOrd + Eq + Ord + Hash + Default,
-    ExampleWithDefaultRef<'_>: Copy + Clone + Debug + !PartialEq + !PartialOrd + !Eq + !Ord + !Hash + !Default + {TryInto<ExampleWithDefault>} + !{Into<ExampleWithDefault>},
+    Example2: !Copy + Clone + Debug + PartialEq + PartialOrd + Eq + Ord + Hash + Default,
+    Example2Ref<'_>: Copy + Clone + Debug + !PartialEq + !PartialOrd + !Eq + !Ord + !Hash + !Default + {TryInto<Example2>} + !{Into<Example2>},
 );


### PR DESCRIPTION
**Checklist**
- [x] Updated CHANGELOG.md with relevant changes
- [x] Added tests for any new/fixed functionality
- [x] Added/updated documentation for new/changed code
- [x] Checked that README.md still makes sense (and updated it if necessary)
