### PR TITLE
Fix clippy

### DIFF
--- a/test/rust-test-2021/src/lib.rs
+++ b/test/rust-test-2021/src/lib.rs
@@ -12,6 +12,7 @@ pub mod planus_test;
 pub mod planus_test_no_flatc;
 
 #[cfg(feature = "std")]
+#[clippy::msrv = "1.75.0"]
 pub mod hexdump;
 
 #[cfg(test)]


### PR DESCRIPTION
Context of this PR: Clippy tries to recommend that we swap out `foo % 2 == 0` in `hexdump.rs` with a call to `is_multiple_of`. What clippy doesn't know is that the same file is symlinked in multiple crates and only some of those crates have a MSRV of 1.75.0, and this method doesn't exist yet for those.

Ideally we would just put 1.75.0 as the MSRV for all of those crates, but the 2024 edition didn't exist then so we can't do that if we also want to test the 2024 edition.

**Checklist**
- [x] Updated CHANGELOG.md with relevant changes
- [x] Added tests for any new/fixed functionality
- [x] Added/updated documentation for new/changed code
- [x] Checked that README.md still makes sense (and updated it if necessary)
