### PR TITLE
Allow keywords as identifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `--version` option to planus-cli [#364](https://github.com/planus-org/planus/pull/364)
 - Parse and preserve union variant metadata in the CST and formatter [#312](https://github.com/planus-org/planus/pull/312).
 - Add `--ignore-unknown-metadata` to allow generating code from schemas that include generator-specific attributes.
+- Allow keywords as identifiers like flatc [#313](https://github.com/planus-org/planus/pull/313)
 
 ### Fixed
 - Fixed rustfmt error handling. Don't return error if rustfmt succeed but prints to stderr, just print out stderr instead. [#363](https://github.com/planus-org/planus/pull/363) [#373](https://github.com/planus-org/planus/pull/373)

--- a/crates/planus-translation/src/parser/grammar.lalrpop
+++ b/crates/planus-translation/src/parser/grammar.lalrpop
@@ -291,8 +291,23 @@ Sign: Sign<'input> = {
   <l: @L> <token: SimpleToken<"-">> <r: @R> => Sign { span: sp(l, r), token, is_negative: true, },
 }
 
-IdentToken: IdentToken<'input> =
-  <l: @L> <token: ident> <r: @R> => IdentToken { span: sp(l, r), token_metadata: token.1, ident: token.0 };
+IdentToken: IdentToken<'input> = {
+  <l: @L> <token: ident> <r: @R> => IdentToken { span: sp(l, r), token_metadata: token.1, ident: token.0 },
+
+  // allow keywords as identifiers (using the keyword's static string)
+  <l: @L> <token_metadata: "include">          <r: @R> => IdentToken { span: sp(l, r), token_metadata, ident: "include" },
+  <l: @L> <token_metadata: "native_include">   <r: @R> => IdentToken { span: sp(l, r), token_metadata, ident: "native_include" },
+  <l: @L> <token_metadata: "namespace">        <r: @R> => IdentToken { span: sp(l, r), token_metadata, ident: "namespace" },
+  <l: @L> <token_metadata: "attribute">        <r: @R> => IdentToken { span: sp(l, r), token_metadata, ident: "attribute" },
+  <l: @L> <token_metadata: "table">            <r: @R> => IdentToken { span: sp(l, r), token_metadata, ident: "table" },
+  <l: @L> <token_metadata: "struct">           <r: @R> => IdentToken { span: sp(l, r), token_metadata, ident: "struct" },
+  <l: @L> <token_metadata: "enum">             <r: @R> => IdentToken { span: sp(l, r), token_metadata, ident: "enum" },
+  <l: @L> <token_metadata: "union">            <r: @R> => IdentToken { span: sp(l, r), token_metadata, ident: "union" },
+  <l: @L> <token_metadata: "root_type">        <r: @R> => IdentToken { span: sp(l, r), token_metadata, ident: "root_type" },
+  <l: @L> <token_metadata: "rpc_service">      <r: @R> => IdentToken { span: sp(l, r), token_metadata, ident: "rpc_service" },
+  <l: @L> <token_metadata: "file_extension">   <r: @R> => IdentToken { span: sp(l, r), token_metadata, ident: "file_extension" },
+  <l: @L> <token_metadata: "file_identifier">  <r: @R> => IdentToken { span: sp(l, r), token_metadata, ident: "file_identifier" },
+};
 
 IntegerLiteral: IntegerLiteral<'input> =
   <l: @L> <token: int> <r: @R> => IntegerLiteral { span: sp(l, r), token_metadata: token.1, value: token.0 };

--- a/test/files/valid/keyword_identifiers.fbs
+++ b/test/files/valid/keyword_identifiers.fbs
@@ -1,0 +1,32 @@
+table include {
+  namespace: int;
+  attribute: int;
+  table: int;
+  struct: int;
+  enum: int;
+  union: int;
+  root_type: int;
+  rpc_service: int;
+  file_extension: int;
+  file_identifier: int;
+}
+
+enum native_include: byte {
+  namespace = 0,
+  attribute = 1,
+  table = 2,
+  struct = 3,
+  enum = 4,
+  union = 5,
+  root_type = 6,
+  rpc_service = 7,
+  file_extension = 8,
+  file_identifier = 9,
+}
+
+table holder {
+  include: include;
+  native_include: native_include;
+}
+
+root_type holder;

--- a/test/rust-test-2021/api_files/keyword_identifiers.fbs
+++ b/test/rust-test-2021/api_files/keyword_identifiers.fbs
@@ -1,0 +1,30 @@
+// Tests that keywords can be used as identifiers, matching flatc behavior.
+
+table include {
+  namespace: int;
+  attribute: int;
+  table: int;
+  struct: int;
+  enum: int;
+  union: int;
+  root_type: int;
+  rpc_service: int;
+  file_extension: int;
+  file_identifier: int;
+}
+
+enum native_include: byte {
+  namespace = 0,
+  attribute = 1,
+  table = 2,
+  struct = 3,
+  enum = 4,
+  union = 5,
+}
+
+table holder {
+  include: include;
+  native_include: native_include;
+}
+
+root_type holder;

--- a/test/rust-test-2021/api_files/keyword_identifiers.rs
+++ b/test/rust-test-2021/api_files/keyword_identifiers.rs
@@ -1,0 +1,22 @@
+// Check that keywords used as field names produce the expected Rust identifiers.
+// Rust keywords get a trailing _ appended by the code generator.
+check_type!(Include => namespace : i32);
+check_type!(Include => attribute : i32);
+check_type!(Include => table : i32);
+check_type!(Include => struct_ : i32);
+check_type!(Include => enum_ : i32);
+check_type!(Include => union_ : i32);
+check_type!(Include => root_type : i32);
+check_type!(Include => rpc_service : i32);
+check_type!(Include => file_extension : i32);
+check_type!(Include => file_identifier : i32);
+
+// Check that keywords used as enum variants produce the expected Rust identifiers.
+check_enum_variants!(NativeInclude: i8 {
+  Namespace = 0,
+  Attribute = 1,
+  Table = 2,
+  Struct = 3,
+  Enum = 4,
+  Union = 5,
+});


### PR DESCRIPTION
This matches the behavior of flatc.

This feels a little hacky but this is my first time seeing larlpop so I'm unsure if there's a better way.
Guidance on suitable tests would be appreciated too.

The specific use case I have is fields called `attribute`. 

**Checklist**
- [x] Updated CHANGELOG.md with relevant changes
- [x] Added tests for any new/fixed functionality
- [ ] Added/updated documentation for new/changed code
- [x] Checked that README.md still makes sense (and updated it if necessary)
