### PR TITLE
Add --serde-tag option for internally tagged union enums

### DIFF
--- a/crates/planus-cli/src/app/rust.rs
+++ b/crates/planus-cli/src/app/rust.rs
@@ -2,7 +2,7 @@ use std::{io::Write, path::PathBuf, process::ExitCode};
 
 use clap::{Parser, ValueHint};
 use color_eyre::Result;
-use planus_codegen::generate_rust;
+use planus_codegen::{generate_rust, RustOptions};
 use planus_translation::translate_files_with_options;
 
 /// Generate rust code
@@ -19,6 +19,13 @@ pub struct Command {
     /// Run rustfmt on the generated code
     #[clap(long, default_value_t = true, action = clap::ArgAction::Set)]
     format: bool,
+
+    /// Emit `#[serde(tag = "<NAME>")]` on generated union enums, producing
+    /// an internally tagged serde representation (e.g. `{"type": "Variant",
+    /// ...fields}`) instead of the default externally tagged one
+    /// (`{"Variant": {...}}`).
+    #[clap(long, value_name = "NAME")]
+    serde_tag: Option<String>,
 }
 
 impl Command {
@@ -29,7 +36,13 @@ impl Command {
             return Ok(ExitCode::FAILURE);
         };
 
-        let res = generate_rust(&declarations, self.format)?;
+        let res = generate_rust(
+            &declarations,
+            &RustOptions {
+                format: self.format,
+                serde_enum_tag: self.serde_tag,
+            },
+        )?;
         let mut file = std::fs::File::create(&self.output_filename)?;
         file.write_all(res.as_bytes())?;
         file.flush()?;

--- a/crates/planus-codegen/src/lib.rs
+++ b/crates/planus-codegen/src/lib.rs
@@ -19,7 +19,22 @@ mod dot;
 mod rust;
 mod templates;
 
-pub fn generate_rust(declarations: &Declarations, format: bool) -> eyre::Result<String> {
+/// Options controlling Rust code generation.
+#[derive(Debug, Clone, Default)]
+pub struct RustOptions {
+    /// Run rustfmt on the generated output.
+    pub format: bool,
+    /// If `Some`, generated union enums are marked with
+    /// `#[serde(tag = "<name>")]`, producing an internally tagged
+    /// representation (`{"<name>": "Variant", ...fields}`) instead of
+    /// the default externally tagged one (`{"Variant": {...}}`).
+    pub serde_enum_tag: Option<String>,
+}
+
+pub fn generate_rust(
+    declarations: &Declarations,
+    options: &RustOptions,
+) -> eyre::Result<String> {
     let default_analysis = run_analysis(declarations, &mut rust::analysis::DefaultAnalysis);
     let eq_analysis = run_analysis(declarations, &mut rust::analysis::EqAnalysis);
     let infallible_analysis = run_analysis(
@@ -31,11 +46,12 @@ pub fn generate_rust(declarations: &Declarations, format: bool) -> eyre::Result<
             default_analysis,
             eq_analysis,
             infallible_analysis,
+            serde_enum_tag: options.serde_enum_tag.clone(),
         },
         declarations,
     );
     let res = templates::rust::Namespace(&output).render().unwrap();
-    if format {
+    if options.format {
         let res = rust::format_string(&res, Some(1_000_000))?;
         let res = rust::format_string(&res, None)?;
         Ok(res)

--- a/crates/planus-codegen/src/rust/mod.rs
+++ b/crates/planus-codegen/src/rust/mod.rs
@@ -23,6 +23,9 @@ pub struct RustBackend {
     pub default_analysis: Vec<bool>,
     pub eq_analysis: Vec<bool>,
     pub infallible_analysis: Vec<bool>,
+    /// If set, generated union enums emit `#[serde(tag = "...")]` so they
+    /// use the internally tagged serde representation.
+    pub serde_enum_tag: Option<String>,
 }
 
 #[derive(Clone, Debug)]
@@ -97,6 +100,7 @@ pub struct Union {
     pub ref_name_with_lifetime: String,
     pub should_do_eq: bool,
     pub should_do_infallible_conversion: bool,
+    pub serde_enum_tag: Option<String>,
 }
 
 #[derive(Clone, Debug)]
@@ -280,6 +284,7 @@ impl Backend for RustBackend {
             ref_name,
             should_do_eq: self.eq_analysis[decl_id.0],
             should_do_infallible_conversion: self.infallible_analysis[decl_id.0],
+            serde_enum_tag: self.serde_enum_tag.clone(),
         }
     }
 

--- a/crates/planus-codegen/src/templates/rust/union.template
+++ b/crates/planus-codegen/src/templates/rust/union.template
@@ -4,6 +4,11 @@
 #[derive(Clone, Debug, PartialEq, PartialOrd,
 {% if info.should_do_eq %}Eq, Ord, Hash,{% endif %}
 ::serde::Serialize, ::serde::Deserialize)]
+{%- match info.serde_enum_tag -%}
+{%- when Some with (tag) -%}
+#[serde(tag = "{{ tag }}")]
+{%- when None -%}
+{%- endmatch %}
 pub enum {{ info.owned_name }}{
     {% for variant in variants -%}
         {% for docstring in variant.name_and_docs.docstrings.iter_strings() %}

--- a/test/rust-test-2021/build.rs
+++ b/test/rust-test-2021/build.rs
@@ -63,8 +63,14 @@ fn generate_test_code(
             let Some(declarations) = planus_translation::translate_files(&[&file_path]) else {
                 bail!("Cannot translate code for {}", file_path.display())
             };
-            let code = planus_codegen::generate_rust(&declarations, true)
-                .wrap_err_with(|| eyre!("Cannot codegen for {}", file_path.display()))?;
+            let code = planus_codegen::generate_rust(
+                &declarations,
+                &planus_codegen::RustOptions {
+                    format: true,
+                    ..Default::default()
+                },
+            )
+            .wrap_err_with(|| eyre!("Cannot codegen for {}", file_path.display()))?;
             std::fs::write(&generated_full_path, code)
                 .wrap_err_with(|| eyre!("Cannot write output to {}", generated_full_path))?;
 


### PR DESCRIPTION
## Summary

- Adds a new `--serde-tag <NAME>` CLI option to `planus rust` and a matching `serde_enum_tag: Option<String>` field on a new public `planus_codegen::RustOptions` struct.
- When set, generated union enums are annotated with `#[serde(tag = "<NAME>")]`, producing serde's internally tagged representation (`{"<NAME>": "Variant", ...fields}`) instead of the default externally tagged one (`{"Variant": {...}}`).
- `planus_codegen::generate_rust` now takes `&RustOptions` in place of the previous `format: bool` parameter. `RustOptions` implements `Default`, so `build.rs` callers can migrate with `&RustOptions { format: true, ..Default::default() }`.

## Example

Given a union like:

```fbs
union Action {
  Move: MoveAction,
  Attack: AttackAction,
}
```

Default (unchanged):
```json
{"Move": {"x": 1, "y": 2}}
```

With `--serde-tag type`:
```json
{"type": "Move", "x": 1, "y": 2}
```

## Caveats

- serde's internally tagged representation requires every variant's payload to serialize as a struct/map. Unions whose variants wrap scalars (e.g. a `string` variant) will fail to compile when this flag is enabled — this matches serde's standard rules and is intentional. Tables and structs work out of the box.
- The `generate_rust` signature change is a minor breaking change for users calling `planus_codegen` directly from a `build.rs`.

## Test plan

- [x] `cargo build -p planus-codegen -p planus-cli`
- [x] `cargo clippy -p planus-codegen -p planus-cli --all-targets` (no warnings)
- [x] Generated both tagged and untagged output for `test/rust-test-2021/api_files/union.fbs` and confirmed the tagged version adds `#[serde(tag = "type")]` on each union enum (including the empty `Union7`).
- [x] Compiled the tagged output against `planus` + `serde` + `serde_json` and roundtripped a `Union4::F3(Box<InnerTable>)` value — serializes to `{"type":"F3","value":7}` and deserializes back.
- [x] Verified default (no-flag) output still compiles unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)