### PR TITLE
Allow ignoring unknown metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Add `--version` option to planus-cli [#364](https://github.com/planus-org/planus/pull/364)
 - Parse and preserve union variant metadata in the CST and formatter [#312](https://github.com/planus-org/planus/pull/312).
+- Add `--ignore-unknown-metadata` to allow generating code from schemas that include generator-specific attributes.
 
 ### Fixed
 - Fixed rustfmt error handling. Don't return error if rustfmt succeed but prints to stderr, just print out stderr instead. [#363](https://github.com/planus-org/planus/pull/363) [#373](https://github.com/planus-org/planus/pull/373)

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -64,6 +64,28 @@ script = '''
         fi
     done
 
+    for f in test/files/ignore-unknown-metadata/*.fbs; do
+        if [ -f "$f" ]; then
+            echo -n "Checking $f without flag: "
+            target/debug/planus check $f >/dev/null 2>&1 && true
+            if [ $? -eq 0 ]; then
+                echo -e "\e[0;31munexpectedly compiled\e[0m"
+                failed=1
+            else
+                echo -e "\e[0;32mfailed as expected\e[0m"
+            fi
+
+            echo -n "Checking $f with --ignore-unknown-metadata: "
+            target/debug/planus --ignore-unknown-metadata check $f >/dev/null 2>&1 && true
+            if [ $? -eq 0 ]; then
+                echo -e "\e[0;32msuccess\e[0m"
+            else
+                echo -e "\e[0;31mcheck failed\e[0m"
+                failed=1
+            fi
+        fi
+    done
+
     if [ "$failed" = "1" ]; then
         echo "cargo make generate failed: $tmpdir"
         exit 1

--- a/crates/planus-cli/src/app/mod.rs
+++ b/crates/planus-cli/src/app/mod.rs
@@ -46,12 +46,16 @@ pub enum Command {
 pub struct AppOptions {
     #[clap(long)]
     pub ignore_docstring_errors: bool,
+
+    #[clap(long)]
+    pub ignore_unknown_metadata: bool,
 }
 
 impl AppOptions {
     pub fn to_converter_options(&self) -> ConverterOptions {
         ConverterOptions {
             ignore_docstring_errors: self.ignore_docstring_errors,
+            ignore_unknown_metadata: self.ignore_unknown_metadata,
         }
     }
 }

--- a/crates/planus-translation/src/ast_convert.rs
+++ b/crates/planus-translation/src/ast_convert.rs
@@ -19,6 +19,7 @@ struct CstConverter<'ctx> {
 #[derive(Copy, Clone, Default, Debug)]
 pub struct ConverterOptions {
     pub ignore_docstring_errors: bool,
+    pub ignore_unknown_metadata: bool,
 }
 
 pub fn convert(
@@ -929,11 +930,13 @@ impl CstConverter<'_> {
 
         if let Some(metadata) = &variant.metadata {
             self.handle_many_invalid_docstrings(metadata.token_metas());
-            self.emit_error(
-                ErrorKind::MISC_SEMANTIC_ERROR,
-                [Label::primary(self.schema.file_id, metadata.span)],
-                Some("metadata on union variants is not supported"),
-            );
+            if !self.converter_options.ignore_unknown_metadata {
+                self.emit_error(
+                    ErrorKind::MISC_SEMANTIC_ERROR,
+                    [Label::primary(self.schema.file_id, metadata.span)],
+                    Some("metadata on union variants is not supported"),
+                );
+            }
         }
 
         if let Some(comma) = &variant.comma {
@@ -1089,6 +1092,9 @@ impl CstConverter<'_> {
                 None
             };
             let key = MetadataValueKindKey::parse(metadata_value.key.ident).or_else(|| {
+                if self_.converter_options.ignore_unknown_metadata {
+                    return None;
+                }
                 self_.emit_error(
                     ErrorKind::MISC_SEMANTIC_ERROR,
                     [Label::primary(

--- a/test/files/ignore-unknown-metadata/unknown_metadata_everywhere.fbs
+++ b/test/files/ignore-unknown-metadata/unknown_metadata_everywhere.fbs
@@ -1,0 +1,24 @@
+table Request (meta_table) {
+  id: uint8 (meta_table_field);
+  kind: Kind (meta_table_field_second);
+}
+
+struct Point (meta_struct) {
+  x: float32 (meta_struct_field_x);
+  y: float32 (meta_struct_field_y);
+}
+
+enum Kind: uint8 (meta_enum) {
+  A,
+  B,
+}
+
+table Reply (meta_table_second) {
+  id: uint8 (meta_reply_field);
+  point: Point (meta_reply_point_field);
+}
+
+union Payload (meta_union) {
+  Request (meta_union_variant_request),
+  R: Reply (meta_union_variant_reply),
+}


### PR DESCRIPTION
Builds on https://github.com/planus-org/planus/pull/312

When using flatbuffers to share data between different languages
that have different generators there can be attributes that are specific
to one particular generator.
E.g., https://github.com/jamescourtney/FlatSharp/wiki/FBS-Annotations#flatsharp-fbs-extensions
In this case, the other generators should just ignore these attributes.

Note: implemented using AI

**Checklist**
- [x] Updated CHANGELOG.md with relevant changes
- [x] Added tests for any new/fixed functionality
- [ ] Added/updated documentation for new/changed code
- [x] Checked that README.md still makes sense (and updated it if necessary)
