### PR TITLE
Add codegen support for rpc_service declarations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add support for `rpc_service` declarations: each service generates a transport-agnostic Rust trait with one method per (unary) rpc method
+- Add support for `rpc_service` declarations: each service generates transport-agnostic sync and async Rust traits with one method per (unary) rpc method
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add support for `rpc_service` declarations: each service generates transport-agnostic sync and async Rust traits with one method per (unary) rpc method
+- Add support for `rpc_service` declarations: each service generates transport-agnostic sync and async Rust traits with one method per (unary) rpc method, plus a method enum with stable numeric ids for routing/relaying messages
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add support for `rpc_service` declarations: each service generates a transport-agnostic Rust trait with one method per (unary) rpc method
+
 ### Fixed
 
 ### Removed

--- a/README.md
+++ b/README.md
@@ -84,10 +84,10 @@ We support most of the base language, though some parts have not been tested in-
 
 Things we do not currently support:
 
-- `rpc_service`
 - `file_extension`, `file_identifier` and `root_type`
 - Fixed-size arrays
-- Any attribute besides `required`, `deprecated`, `id` or `force_align`.
+- Streaming rpc methods (`rpc_service` is supported, but only with unary methods)
+- Any attribute besides `required`, `deprecated`, `id`, `force_align`, `idempotent` or `streaming`.
 - Some of the more exotic literal values, like hexadecimal floats or unicode surrogate pair parsing.
 
 Things we will probably never support:

--- a/crates/planus-codegen/src/backend.rs
+++ b/crates/planus-codegen/src/backend.rs
@@ -294,6 +294,15 @@ pub trait Backend {
         decl: &Union,
     ) -> Self::UnionInfo;
 
+    fn generate_rpc_service(
+        &mut self,
+        declaration_names: &mut DeclarationNames<'_, '_>,
+        translated_namespaces: &[Self::NamespaceInfo],
+        decl_id: DeclarationIndex,
+        decl_name: &AbsolutePath,
+        decl: &RpcService,
+    ) -> Self::RpcServiceInfo;
+
     fn generate_table_field(
         &mut self,
         translation_context: &mut DeclarationTranslationContext<'_, '_, Self>,
@@ -334,4 +343,16 @@ pub trait Backend {
         value: &UnionVariant,
         resolved_type: ResolvedType<'_, Self>,
     ) -> Self::UnionVariantInfo;
+
+    #[allow(clippy::too_many_arguments)]
+    fn generate_rpc_method(
+        &mut self,
+        translation_context: &mut DeclarationTranslationContext<'_, '_, Self>,
+        parent_info: &Self::RpcServiceInfo,
+        parent: &RpcService,
+        method_name: &str,
+        method: &RpcMethod,
+        argument_type: ResolvedType<'_, Self>,
+        return_type: ResolvedType<'_, Self>,
+    ) -> Self::RpcMethodInfo;
 }

--- a/crates/planus-codegen/src/backend_translation.rs
+++ b/crates/planus-codegen/src/backend_translation.rs
@@ -26,7 +26,6 @@ pub enum BackendDeclaration<B: ?Sized + Backend> {
     Struct(BackendStruct<B>),
     Enum(BackendEnum<B>),
     Union(BackendUnion<B>),
-    #[allow(dead_code)]
     RpcService(BackendRpcService<B>),
 }
 
@@ -66,9 +65,9 @@ pub struct BackendUnion<B: ?Sized + Backend> {
 
 #[derive(Debug, Clone)]
 pub struct BackendRpcService<B: ?Sized + Backend> {
-    pub _docstrings: Docstrings,
-    pub _info: B::RpcServiceInfo,
-    pub _methods: Vec<B::RpcMethodInfo>,
+    pub docstrings: Docstrings,
+    pub info: B::RpcServiceInfo,
+    pub methods: Vec<BackendVariant<B::RpcMethodInfo>>,
 }
 
 #[derive(Debug, Clone)]
@@ -299,7 +298,9 @@ fn translate_type_index<'a, B: ?Sized + Backend>(
         DeclInfo::Union(translated_decl, decl) => {
             ResolvedType::Union(index, decl, translated_decl, relative_path)
         }
-        DeclInfo::RpcService(_translated_decl, _decl) => todo!(),
+        DeclInfo::RpcService(_translated_decl, _decl) => {
+            unreachable!("rpc services cannot be used as types")
+        }
     }
 }
 
@@ -494,7 +495,20 @@ pub fn run_backend<B: ?Sized + Backend>(
                     ),
                     decl,
                 ),
-                DeclarationKind::RpcService(_decl) => todo!(),
+                DeclarationKind::RpcService(decl) => DeclInfo::RpcService(
+                    backend.generate_rpc_service(
+                        &mut DeclarationNames {
+                            _global_names: global_names,
+                            _namespace_names: namespace_names,
+                            declaration_names,
+                        },
+                        &translated_namespaces,
+                        DeclarationIndex(decl_id),
+                        decl_name,
+                        decl,
+                    ),
+                    decl,
+                ),
             };
             (decl_name.clone(), decl)
         })
@@ -650,7 +664,47 @@ pub fn run_backend<B: ?Sized + Backend>(
                     .collect(),
                 docstrings: (orig_decl.1).docstrings.clone(),
             }),
-            DeclInfo::RpcService(_translated_decl, _decl) => todo!(),
+            DeclInfo::RpcService(translated_decl, decl) => {
+                BackendDeclaration::RpcService(BackendRpcService {
+                    info: translated_decl.clone(),
+                    methods: decl
+                        .methods
+                        .iter()
+                        .map(|(method_name, method)| {
+                            let argument_type = translate_type(
+                                &translation_context,
+                                declarations,
+                                &full_translated_decls,
+                                &method.argument_type,
+                                &decl_path.clone_pop(),
+                            );
+                            let return_type = translate_type(
+                                &translation_context,
+                                declarations,
+                                &full_translated_decls,
+                                &method.return_type,
+                                &decl_path.clone_pop(),
+                            );
+                            BackendVariant {
+                                name_and_docs: NameAndDocstrings {
+                                    original_name: method_name.clone(),
+                                    docstrings: method.docstrings.clone(),
+                                },
+                                variant: backend.generate_rpc_method(
+                                    &mut translation_context,
+                                    translated_decl,
+                                    decl,
+                                    method_name,
+                                    method,
+                                    argument_type,
+                                    return_type,
+                                ),
+                            }
+                        })
+                        .collect(),
+                    docstrings: (orig_decl.1).docstrings.clone(),
+                })
+            }
         };
         full_translated_decls.insert(i, decl);
     }

--- a/crates/planus-codegen/src/dot/mod.rs
+++ b/crates/planus-codegen/src/dot/mod.rs
@@ -75,17 +75,19 @@ pub struct UnionVariant {
 
 #[derive(Clone, Debug)]
 pub struct RpcService {
-    pub _decl_id: DeclarationIndex,
-    pub _name: String,
+    pub decl_id: DeclarationIndex,
+    pub name: String,
 }
 
 #[derive(Clone, Debug)]
 pub struct RpcMethod {
-    pub _name: String,
-    pub _arg_type: String,
-    pub _arg_type_ref: Option<DeclarationIndex>,
-    pub _return_type: String,
-    pub _return_type_ref: Option<DeclarationIndex>,
+    pub name: String,
+    pub argument_type: Cow<'static, str>,
+    pub argument_type_ref: Option<DeclarationIndex>,
+    pub argument_color: String,
+    pub return_type: Cow<'static, str>,
+    pub return_type_ref: Option<DeclarationIndex>,
+    pub return_color: String,
 }
 
 impl DotBackend {
@@ -211,6 +213,20 @@ impl Backend for DotBackend {
         }
     }
 
+    fn generate_rpc_service(
+        &mut self,
+        _declaration_names: &mut DeclarationNames<'_, '_>,
+        _translated_namespaces: &[Self::NamespaceInfo],
+        decl_id: DeclarationIndex,
+        decl_name: &AbsolutePath,
+        _decl: &intermediate::RpcService,
+    ) -> RpcService {
+        RpcService {
+            decl_id,
+            name: decl_name.to_string(),
+        }
+    }
+
     fn generate_table_field(
         &mut self,
         _translation_context: &mut DeclarationTranslationContext<'_, '_, Self>,
@@ -305,6 +321,30 @@ impl Backend for DotBackend {
             type_,
             type_ref,
             color: self.random_color(),
+        }
+    }
+
+    fn generate_rpc_method(
+        &mut self,
+        _translation_context: &mut DeclarationTranslationContext<'_, '_, Self>,
+        _parent_info: &Self::RpcServiceInfo,
+        _parent: &intermediate::RpcService,
+        method_name: &str,
+        _method: &intermediate::RpcMethod,
+        argument_type: ResolvedType<'_, Self>,
+        return_type: ResolvedType<'_, Self>,
+    ) -> RpcMethod {
+        let (argument_type, argument_type_ref) = get_name(&argument_type);
+        let (return_type, return_type_ref) = get_name(&return_type);
+
+        RpcMethod {
+            name: method_name.to_string(),
+            argument_type,
+            argument_type_ref,
+            argument_color: self.random_color(),
+            return_type,
+            return_type_ref,
+            return_color: self.random_color(),
         }
     }
 }

--- a/crates/planus-codegen/src/rust/mod.rs
+++ b/crates/planus-codegen/src/rust/mod.rs
@@ -115,12 +115,14 @@ pub struct UnionVariant {
 pub struct RpcService {
     pub trait_name: String,
     pub async_trait_name: String,
+    pub method_enum_name: String,
     pub service_name: String,
 }
 
 #[derive(Clone, Debug)]
 pub struct RpcMethod {
     pub name: String,
+    pub variant_name: String,
     pub argument_ref_type: String,
     pub return_owned_type: String,
     pub idempotent: bool,
@@ -305,6 +307,7 @@ impl Backend for RustBackend {
         RpcService {
             trait_name: reserve_type_name(decl_name, declaration_names),
             async_trait_name: reserve_type_name(&format!("{decl_name}Async"), declaration_names),
+            method_enum_name: reserve_type_name(&format!("{decl_name}Method"), declaration_names),
             service_name,
         }
     }
@@ -1031,6 +1034,11 @@ impl Backend for RustBackend {
             "name",
             &mut translation_context.declaration_names,
         );
+        let variant_name = reserve_rust_enum_variant_name(
+            method_name,
+            "variant_name",
+            &mut translation_context.declaration_names,
+        );
         let argument_ref_type = match argument_type {
             ResolvedType::Table(_, _, info, relative_namespace) => format!(
                 "{}<'_>",
@@ -1046,6 +1054,7 @@ impl Backend for RustBackend {
         };
         RpcMethod {
             name,
+            variant_name,
             argument_ref_type,
             return_owned_type,
             idempotent: method.idempotent,

--- a/crates/planus-codegen/src/rust/mod.rs
+++ b/crates/planus-codegen/src/rust/mod.rs
@@ -114,6 +114,7 @@ pub struct UnionVariant {
 #[derive(Clone, Debug)]
 pub struct RpcService {
     pub trait_name: String,
+    pub async_trait_name: String,
     pub service_name: String,
 }
 
@@ -303,6 +304,7 @@ impl Backend for RustBackend {
         let decl_name = decl_name.0.last().unwrap();
         RpcService {
             trait_name: reserve_type_name(decl_name, declaration_names),
+            async_trait_name: reserve_type_name(&format!("{decl_name}Async"), declaration_names),
             service_name,
         }
     }

--- a/crates/planus-codegen/src/rust/mod.rs
+++ b/crates/planus-codegen/src/rust/mod.rs
@@ -112,10 +112,18 @@ pub struct UnionVariant {
 }
 
 #[derive(Clone, Debug)]
-pub struct RpcService {}
+pub struct RpcService {
+    pub trait_name: String,
+    pub service_name: String,
+}
 
 #[derive(Clone, Debug)]
-pub struct RpcMethod {}
+pub struct RpcMethod {
+    pub name: String,
+    pub argument_ref_type: String,
+    pub return_owned_type: String,
+    pub idempotent: bool,
+}
 
 const BINDING_KIND_TYPES: &str = "types";
 
@@ -280,6 +288,22 @@ impl Backend for RustBackend {
             ref_name,
             should_do_eq: self.eq_analysis[decl_id.0],
             should_do_infallible_conversion: self.infallible_analysis[decl_id.0],
+        }
+    }
+
+    fn generate_rpc_service(
+        &mut self,
+        declaration_names: &mut DeclarationNames<'_, '_>,
+        _translated_namespaces: &[Self::NamespaceInfo],
+        _decl_id: DeclarationIndex,
+        decl_name: &AbsolutePath,
+        _decl: &intermediate::RpcService,
+    ) -> RpcService {
+        let service_name = decl_name.to_string();
+        let decl_name = decl_name.0.last().unwrap();
+        RpcService {
+            trait_name: reserve_type_name(decl_name, declaration_names),
+            service_name,
         }
     }
 
@@ -987,6 +1011,42 @@ impl Backend for RustBackend {
             ref_type,
             is_struct,
             can_do_infallible_conversion,
+        }
+    }
+
+    fn generate_rpc_method(
+        &mut self,
+        translation_context: &mut DeclarationTranslationContext<'_, '_, Self>,
+        _parent_info: &Self::RpcServiceInfo,
+        _parent: &intermediate::RpcService,
+        method_name: &str,
+        method: &intermediate::RpcMethod,
+        argument_type: ResolvedType<'_, Self>,
+        return_type: ResolvedType<'_, Self>,
+    ) -> RpcMethod {
+        let name = reserve_field_name(
+            method_name,
+            "name",
+            &mut translation_context.declaration_names,
+        );
+        let argument_ref_type = match argument_type {
+            ResolvedType::Table(_, _, info, relative_namespace) => format!(
+                "{}<'_>",
+                format_relative_namespace(&relative_namespace, &info.ref_name)
+            ),
+            _ => unreachable!("rpc method types are checked to be tables"),
+        };
+        let return_owned_type = match return_type {
+            ResolvedType::Table(_, _, info, relative_namespace) => {
+                format_relative_namespace(&relative_namespace, &info.owned_name).to_string()
+            }
+            _ => unreachable!("rpc method types are checked to be tables"),
+        };
+        RpcMethod {
+            name,
+            argument_ref_type,
+            return_owned_type,
+            idempotent: method.idempotent,
         }
     }
 }

--- a/crates/planus-codegen/src/rust/mod.rs
+++ b/crates/planus-codegen/src/rust/mod.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use eyre::Context;
-use heck::{ToSnakeCase, ToUpperCamelCase};
+use heck::{ToShoutySnakeCase, ToSnakeCase, ToUpperCamelCase};
 use planus_types::{
     ast::{FloatType, IntegerType},
     intermediate::{self, AbsolutePath, AssignMode, DeclarationIndex, Literal, TableFieldTagKind},
@@ -116,6 +116,7 @@ pub struct RpcService {
     pub trait_name: String,
     pub async_trait_name: String,
     pub method_enum_name: String,
+    pub name_const: String,
     pub service_name: String,
 }
 
@@ -140,6 +141,14 @@ fn reserve_module_name(path: &str, namespace_names: &mut NamespaceNames<'_, '_>)
 
 fn reserve_type_name(path: &str, declaration_names: &mut DeclarationNames<'_, '_>) -> String {
     let name = path.to_upper_camel_case().into();
+    declaration_names
+        .declaration_names
+        .try_reserve_repeat(BINDING_KIND_TYPES, name, '_')
+        .into()
+}
+
+fn reserve_const_name(path: &str, declaration_names: &mut DeclarationNames<'_, '_>) -> String {
+    let name = path.to_shouty_snake_case().into();
     declaration_names
         .declaration_names
         .try_reserve_repeat(BINDING_KIND_TYPES, name, '_')
@@ -308,6 +317,7 @@ impl Backend for RustBackend {
             trait_name: reserve_type_name(decl_name, declaration_names),
             async_trait_name: reserve_type_name(&format!("{decl_name}Async"), declaration_names),
             method_enum_name: reserve_type_name(&format!("{decl_name}Method"), declaration_names),
+            name_const: reserve_const_name(&format!("{decl_name}Name"), declaration_names),
             service_name,
         }
     }

--- a/crates/planus-codegen/src/templates/dot/rpc_service.template
+++ b/crates/planus-codegen/src/templates/dot/rpc_service.template
@@ -1,0 +1,26 @@
+  decl{{info.decl_id}}[ label=<
+    <TABLE BORDER="0" CELLBORDER="1" CELLSPACING="0" CELLPADDING="4">
+      <TR>
+        <TD colspan="3" PORT="name">rpc_service {{info.name}}</TD>
+      </TR>
+      {%- for (method_id, method) in methods.iter().enumerate() %}
+      <TR>
+        <TD>{{method.name}}</TD>
+        <TD PORT="arg{{method_id}}">{{method.argument_type}}</TD>
+        <TD PORT="ret{{method_id}}">{{method.return_type}}</TD>
+      </TR>
+      {%- endfor %}
+    </TABLE>>
+  ];
+  {%- for (method_id, method) in methods.iter().enumerate() -%}
+  {%- match method.argument_type_ref -%}
+  {%- when Some with (v) %}
+  decl{{info.decl_id}}:arg{{method_id}}:e -> decl{{v}}:name [color = "{{method.argument_color}}"];
+  {%- when None -%}
+  {%- endmatch -%}
+  {%- match method.return_type_ref -%}
+  {%- when Some with (v) %}
+  decl{{info.decl_id}}:ret{{method_id}}:e -> decl{{v}}:name [color = "{{method.return_color}}"];
+  {%- when None -%}
+  {%- endmatch -%}
+  {%- endfor %}

--- a/crates/planus-codegen/src/templates/rust/rpc_service.template
+++ b/crates/planus-codegen/src/templates/rust/rpc_service.template
@@ -49,3 +49,72 @@ pub trait {{ info.async_trait_name }} {
     async fn {{ method.name }}(&self, request: {{ method.argument_ref_type }}) -> ::core::result::Result<{{ method.return_owned_type }}, Self::Error>;
     {% endfor %}
 }
+
+/// The methods of the rpc service `{{ info.service_name }}`.
+///
+/// Each method has a numeric id given by its zero-based position in the
+/// service declaration, which can be used to relay or route messages.
+/// Note that the ids follow declaration order, so removing or reordering
+/// methods in the schema changes them.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, ::serde::Serialize, ::serde::Deserialize)]
+{%- if !methods.is_empty() -%}
+#[repr(u32)]
+{%- endif -%}
+pub enum {{ info.method_enum_name }} {
+    {% for method in methods -%}
+        {% for docstring in method.name_and_docs.docstrings.iter_strings() %}
+        /// {{ docstring }}
+        {%- endfor %}
+        {{ method.variant_name }} = {{ loop.index0 }},
+    {% endfor %}
+}
+
+impl {{ info.method_enum_name }} {
+    /// Array containing all methods of the service, ordered by id
+    pub const ENUM_VALUES: [Self; {{ methods.len() }}] = [
+        {%- for method in methods -%} Self::{{ method.variant_name }}, {%- endfor -%}
+    ];
+
+    /// The id of the method, given by its zero-based position in the
+    /// service declaration
+    #[inline]
+    pub fn id(self) -> u32 {
+        match self {
+            {% for method in methods -%}
+                Self::{{ method.variant_name }} => {{ loop.index0 }},
+            {% endfor %}
+        }
+    }
+
+    /// The name of the method as declared in the flatbuffers schema
+    #[inline]
+    pub fn name(self) -> &'static str {
+        match self {
+            {% for method in methods -%}
+                Self::{{ method.variant_name }} => "{{ method.name_and_docs.original_name }}",
+            {% endfor %}
+        }
+    }
+}
+
+impl ::core::convert::TryFrom<u32> for {{ info.method_enum_name }} {
+    type Error = ::planus::errors::UnknownEnumTagKind;
+    #[inline]
+    fn try_from(value: u32) -> ::core::result::Result<Self, ::planus::errors::UnknownEnumTagKind> {
+        #[allow(clippy::match_single_binding)]
+        match value {
+            {% for method in methods -%}
+                {{ loop.index0 }} => ::core::result::Result::Ok(Self::{{ method.variant_name }}),
+            {% endfor %}
+
+            _ => ::core::result::Result::Err(::planus::errors::UnknownEnumTagKind { tag: value as i128 }),
+        }
+    }
+}
+
+impl ::core::convert::From<{{ info.method_enum_name }}> for u32 {
+    #[inline]
+    fn from(value: {{ info.method_enum_name }}) -> Self {
+        value.id()
+    }
+}

--- a/crates/planus-codegen/src/templates/rust/rpc_service.template
+++ b/crates/planus-codegen/src/templates/rust/rpc_service.template
@@ -1,0 +1,24 @@
+{% for docstring in docstrings.iter_strings() %}
+/// {{ docstring }}
+{%- endfor %}
+///
+/// This trait is transport-agnostic: implement it to handle the requests
+/// of the rpc service using any transport of your choosing.
+pub trait {{ info.trait_name }} {
+    /// The fully-qualified name of this service in the flatbuffers schema.
+    const NAME: &'static str = "{{ info.service_name }}";
+
+    /// The error type returned by the methods of this service.
+    type Error;
+
+    {% for method in methods -%}
+    {% for docstring in method.name_and_docs.docstrings.iter_strings() %}
+    /// {{ docstring }}
+    {%- endfor %}
+    {%- if method.idempotent %}
+    ///
+    /// This method is marked as `idempotent` in the flatbuffers schema.
+    {%- endif %}
+    fn {{ method.name }}(&self, request: {{ method.argument_ref_type }}) -> ::core::result::Result<{{ method.return_owned_type }}, Self::Error>;
+    {% endfor %}
+}

--- a/crates/planus-codegen/src/templates/rust/rpc_service.template
+++ b/crates/planus-codegen/src/templates/rust/rpc_service.template
@@ -22,3 +22,30 @@ pub trait {{ info.trait_name }} {
     fn {{ method.name }}(&self, request: {{ method.argument_ref_type }}) -> ::core::result::Result<{{ method.return_owned_type }}, Self::Error>;
     {% endfor %}
 }
+
+{% for docstring in docstrings.iter_strings() %}
+/// {{ docstring }}
+{%- endfor %}
+///
+/// This is the async version of [`{{ info.trait_name }}`]. It is
+/// transport-agnostic: implement it to handle the requests of the rpc
+/// service using any transport of your choosing.
+#[allow(async_fn_in_trait)]
+pub trait {{ info.async_trait_name }} {
+    /// The fully-qualified name of this service in the flatbuffers schema.
+    const NAME: &'static str = "{{ info.service_name }}";
+
+    /// The error type returned by the methods of this service.
+    type Error;
+
+    {% for method in methods -%}
+    {% for docstring in method.name_and_docs.docstrings.iter_strings() %}
+    /// {{ docstring }}
+    {%- endfor %}
+    {%- if method.idempotent %}
+    ///
+    /// This method is marked as `idempotent` in the flatbuffers schema.
+    {%- endif %}
+    async fn {{ method.name }}(&self, request: {{ method.argument_ref_type }}) -> ::core::result::Result<{{ method.return_owned_type }}, Self::Error>;
+    {% endfor %}
+}

--- a/crates/planus-codegen/src/templates/rust/rpc_service.template
+++ b/crates/planus-codegen/src/templates/rust/rpc_service.template
@@ -1,3 +1,7 @@
+/// The fully-qualified name of the `{{ info.trait_name }}` service in the
+/// flatbuffers schema.
+pub const {{ info.name_const }}: &str = "{{ info.service_name }}";
+
 {% for docstring in docstrings.iter_strings() %}
 /// {{ docstring }}
 {%- endfor %}
@@ -6,7 +10,9 @@
 /// of the rpc service using any transport of your choosing.
 pub trait {{ info.trait_name }} {
     /// The fully-qualified name of this service in the flatbuffers schema.
-    const NAME: &'static str = "{{ info.service_name }}";
+    ///
+    /// Also available without an implementing type as [`{{ info.name_const }}`].
+    const NAME: &'static str = {{ info.name_const }};
 
     /// The error type returned by the methods of this service.
     type Error;
@@ -33,7 +39,9 @@ pub trait {{ info.trait_name }} {
 #[allow(async_fn_in_trait)]
 pub trait {{ info.async_trait_name }} {
     /// The fully-qualified name of this service in the flatbuffers schema.
-    const NAME: &'static str = "{{ info.service_name }}";
+    ///
+    /// Also available without an implementing type as [`{{ info.name_const }}`].
+    const NAME: &'static str = {{ info.name_const }};
 
     /// The error type returned by the methods of this service.
     type Error;
@@ -70,6 +78,9 @@ pub enum {{ info.method_enum_name }} {
 }
 
 impl {{ info.method_enum_name }} {
+    /// The fully-qualified name of the service in the flatbuffers schema
+    pub const SERVICE_NAME: &'static str = {{ info.name_const }};
+
     /// Array containing all methods of the service, ordered by id
     pub const ENUM_VALUES: [Self; {{ methods.len() }}] = [
         {%- for method in methods -%} Self::{{ method.variant_name }}, {%- endfor -%}

--- a/crates/planus-translation/src/intermediate_language/checks/compatibility.rs
+++ b/crates/planus-translation/src/intermediate_language/checks/compatibility.rs
@@ -22,13 +22,6 @@ pub fn check_ast(ctx: &Ctx, schema: &ast::Schema) {
 
     for decl in schema.type_declarations.values() {
         match &decl.kind {
-            ast::TypeDeclarationKind::RpcService(_) => {
-                ctx.emit_error(
-                    ErrorKind::NOT_SUPPORTED,
-                    [Label::primary(schema.file_id, decl.definition_span)],
-                    Some("Rpc services are not currently supported"),
-                );
-            }
             ast::TypeDeclarationKind::Struct(inner_decl) if inner_decl.fields.is_empty() => {
                 ctx.emit_error(
                     ErrorKind::NOT_SUPPORTED,

--- a/crates/planus-translation/src/intermediate_language/translation.rs
+++ b/crates/planus-translation/src/intermediate_language/translation.rs
@@ -989,13 +989,95 @@ impl<'a> Translator<'a> {
 
     fn translate_rpc_service(
         &self,
-        _current_namespace: &AbsolutePath,
-        _current_file_id: FileId,
-        _decl: &ast::RpcService,
+        current_namespace: &AbsolutePath,
+        current_file_id: FileId,
+        decl: &ast::RpcService,
     ) -> RpcService {
-        RpcService {
-            methods: Default::default(),
+        let methods = decl
+            .methods
+            .iter()
+            .filter_map(|(ident, method)| {
+                self.translate_rpc_method(current_namespace, current_file_id, method, ident)
+            })
+            .collect();
+        RpcService { methods }
+    }
+
+    fn check_valid_rpc_method_type(&self, current_file_id: FileId, type_: &Type) -> bool {
+        if matches!(type_.kind, TypeKind::Table(_)) {
+            true
+        } else {
+            self.ctx.emit_error(
+                ErrorKind::TYPE_ERROR,
+                [Label::primary(current_file_id, type_.span)
+                    .with_message("Rpc methods only support tables as argument and return types")],
+                Some("Unsupported type"),
+            );
+            false
         }
+    }
+
+    fn translate_rpc_method(
+        &self,
+        current_namespace: &AbsolutePath,
+        current_file_id: FileId,
+        method: &ast::RpcMethod,
+        ident: &string_interner::symbol::SymbolU32,
+    ) -> Option<(String, RpcMethod)> {
+        let mut idempotent = false;
+        for m in &method.metadata.values {
+            match &m.kind {
+                MetadataValueKind::Streaming(value) => match value.value.as_str() {
+                    "none" => (),
+                    "client" | "server" | "bidi" => {
+                        self.ctx.emit_error(
+                            ErrorKind::NOT_SUPPORTED,
+                            [Label::primary(current_file_id, m.span)],
+                            Some("Streaming rpc methods are not currently supported"),
+                        );
+                    }
+                    _ => {
+                        self.ctx.emit_error(
+                            ErrorKind::MISC_SEMANTIC_ERROR,
+                            [Label::primary(current_file_id, m.span)],
+                            Some(
+                                "Streaming must be one of \"none\", \"client\", \"server\" or \"bidi\"",
+                            ),
+                        );
+                    }
+                },
+                MetadataValueKind::Idempotent => idempotent = true,
+                _ => {
+                    self.emit_metadata_support_error(
+                        current_file_id,
+                        m,
+                        "rpc methods",
+                        m.kind.accepted_on_rpc_methods(),
+                    );
+                }
+            }
+        }
+
+        let argument_type =
+            self.translate_type(current_namespace, current_file_id, &method.argument_type);
+        let return_type =
+            self.translate_type(current_namespace, current_file_id, &method.return_type);
+        let (argument_type, return_type) = (argument_type?, return_type?);
+        let argument_type_valid = self.check_valid_rpc_method_type(current_file_id, &argument_type);
+        let return_type_valid = self.check_valid_rpc_method_type(current_file_id, &return_type);
+        if !argument_type_valid || !return_type_valid {
+            return None;
+        }
+
+        Some((
+            self.ctx.resolve_identifier(*ident),
+            RpcMethod {
+                argument_type,
+                return_type,
+                idempotent,
+                docstrings: method.docstrings.clone(),
+            },
+        ))
     }
 
     fn emit_metadata_support_error(

--- a/crates/planus-types/src/intermediate.rs
+++ b/crates/planus-types/src/intermediate.rs
@@ -344,6 +344,8 @@ pub struct RpcService {
 pub struct RpcMethod {
     pub argument_type: Type,
     pub return_type: Type,
+    pub idempotent: bool,
+    pub docstrings: Docstrings,
 }
 
 #[derive(Debug, PartialEq, Eq, Hash)]

--- a/test/files/invalid/defined_twice.stderr
+++ b/test/files/invalid/defined_twice.stderr
@@ -54,9 +54,15 @@ error: cannot define rpc method x twice
 30 │   x(uint32): uint32;
    │   ------------------ second method was here
 
-error: Rpc services are not currently supported
-   ┌─ test/files/invalid/defined_twice.fbs:28:1
+error: Unsupported type
+   ┌─ test/files/invalid/defined_twice.fbs:29:5
    │
-28 │ rpc_service A5 {
-   │ ^^^^^^^^^^^^^^
+29 │   x(string): string;
+   │     ^^^^^^ Rpc methods only support tables as argument and return types
+
+error: Unsupported type
+   ┌─ test/files/invalid/defined_twice.fbs:29:14
+   │
+29 │   x(string): string;
+   │              ^^^^^^ Rpc methods only support tables as argument and return types
 

--- a/test/files/invalid/rpc_bad_types.fbs
+++ b/test/files/invalid/rpc_bad_types.fbs
@@ -1,0 +1,13 @@
+struct Vec2 {
+  x: float;
+  y: float;
+}
+
+table Foo {
+  x: int;
+}
+
+rpc_service Bad {
+  M1(Vec2): Foo;
+  M2(Foo): string;
+}

--- a/test/files/invalid/rpc_bad_types.stderr
+++ b/test/files/invalid/rpc_bad_types.stderr
@@ -1,0 +1,12 @@
+error: Unsupported type
+   ┌─ test/files/invalid/rpc_bad_types.fbs:11:6
+   │
+11 │   M1(Vec2): Foo;
+   │      ^^^^ Rpc methods only support tables as argument and return types
+
+error: Unsupported type
+   ┌─ test/files/invalid/rpc_bad_types.fbs:12:12
+   │
+12 │   M2(Foo): string;
+   │            ^^^^^^ Rpc methods only support tables as argument and return types
+

--- a/test/files/invalid/rpc_service_as_type.stderr
+++ b/test/files/invalid/rpc_service_as_type.stderr
@@ -1,9 +1,3 @@
-error: Rpc services are not currently supported
-  ┌─ test/files/invalid/rpc_service_as_type.fbs:5:1
-  │
-5 │ rpc_service Bar {
-  │ ^^^^^^^^^^^^^^^
-
 error: Cannot use the RpcService Bar in a type context
   ┌─ test/files/invalid/rpc_service_as_type.fbs:2:6
   │

--- a/test/files/invalid/rpc_streaming.fbs
+++ b/test/files/invalid/rpc_streaming.fbs
@@ -1,0 +1,10 @@
+table Foo {
+  x: int;
+}
+
+rpc_service Bad {
+  M1(Foo): Foo (streaming: "client");
+  M2(Foo): Foo (streaming: "server");
+  M3(Foo): Foo (streaming: "bidi");
+  M4(Foo): Foo (streaming: "nonsense");
+}

--- a/test/files/invalid/rpc_streaming.stderr
+++ b/test/files/invalid/rpc_streaming.stderr
@@ -1,0 +1,24 @@
+error: Streaming rpc methods are not currently supported
+  ┌─ test/files/invalid/rpc_streaming.fbs:6:17
+  │
+6 │   M1(Foo): Foo (streaming: "client");
+  │                 ^^^^^^^^^^^^^^^^^^^
+
+error: Streaming rpc methods are not currently supported
+  ┌─ test/files/invalid/rpc_streaming.fbs:7:17
+  │
+7 │   M2(Foo): Foo (streaming: "server");
+  │                 ^^^^^^^^^^^^^^^^^^^
+
+error: Streaming rpc methods are not currently supported
+  ┌─ test/files/invalid/rpc_streaming.fbs:8:17
+  │
+8 │   M3(Foo): Foo (streaming: "bidi");
+  │                 ^^^^^^^^^^^^^^^^^
+
+error: Streaming must be one of "none", "client", "server" or "bidi"
+  ┌─ test/files/invalid/rpc_streaming.fbs:9:17
+  │
+9 │   M4(Foo): Foo (streaming: "nonsense");
+  │                 ^^^^^^^^^^^^^^^^^^^^^
+

--- a/test/files/valid/rpc_service.fbs
+++ b/test/files/valid/rpc_service.fbs
@@ -1,0 +1,16 @@
+namespace example;
+
+table HelloRequest {
+  name: string;
+}
+
+table HelloReply {
+  message: string;
+}
+
+/// A simple greeting service.
+rpc_service Greeter {
+  SayHello(HelloRequest): HelloReply;
+  /// Says hello, but is also idempotent.
+  SayHelloAgain(HelloRequest): HelloReply (idempotent, streaming: "none");
+}

--- a/test/rust-test-2021/api_files/rpc_service.fbs
+++ b/test/rust-test-2021/api_files/rpc_service.fbs
@@ -1,0 +1,14 @@
+table HelloRequest {
+  name: string;
+}
+
+table HelloReply {
+  message: string (required);
+}
+
+/// A simple greeting service.
+rpc_service Greeter {
+  SayHello(HelloRequest): HelloReply;
+  /// Says hello, but is also idempotent.
+  SayHelloAgain(HelloRequest): HelloReply (idempotent, streaming: "none");
+}

--- a/test/rust-test-2021/api_files/rpc_service.rs
+++ b/test/rust-test-2021/api_files/rpc_service.rs
@@ -1,0 +1,30 @@
+use planus::ReadAsRoot;
+
+struct MyGreeter;
+
+impl Greeter for MyGreeter {
+    type Error = planus::Error;
+
+    fn say_hello(&self, request: HelloRequestRef<'_>) -> Result<HelloReply, Self::Error> {
+        Ok(HelloReply {
+            message: format!("Hello, {}!", request.name()?.unwrap_or("world")),
+        })
+    }
+
+    fn say_hello_again(&self, request: HelloRequestRef<'_>) -> Result<HelloReply, Self::Error> {
+        self.say_hello(request)
+    }
+}
+
+assert_eq!(<MyGreeter as Greeter>::NAME, "Greeter");
+
+let mut builder = planus::Builder::new();
+let offset = HelloRequest::create(&mut builder, "Planus");
+let data = builder.finish(offset, None);
+
+let request = HelloRequestRef::read_as_root(data).unwrap();
+let reply = MyGreeter.say_hello(request).unwrap();
+assert_eq!(reply.message, "Hello, Planus!");
+
+let reply = MyGreeter.say_hello_again(request).unwrap();
+assert_eq!(reply.message, "Hello, Planus!");

--- a/test/rust-test-2021/api_files/rpc_service.rs
+++ b/test/rust-test-2021/api_files/rpc_service.rs
@@ -41,6 +41,8 @@ impl GreeterAsync for MyAsyncGreeter {
     }
 }
 
+assert_eq!(GREETER_NAME, "Greeter");
+assert_eq!(GreeterMethod::SERVICE_NAME, "Greeter");
 assert_eq!(<MyGreeter as Greeter>::NAME, "Greeter");
 assert_eq!(<MyAsyncGreeter as GreeterAsync>::NAME, "Greeter");
 

--- a/test/rust-test-2021/api_files/rpc_service.rs
+++ b/test/rust-test-2021/api_files/rpc_service.rs
@@ -1,3 +1,9 @@
+use core::{
+    future::Future,
+    pin::pin,
+    task::{Context, Poll, Waker},
+};
+
 use planus::ReadAsRoot;
 
 struct MyGreeter;
@@ -16,7 +22,27 @@ impl Greeter for MyGreeter {
     }
 }
 
+struct MyAsyncGreeter;
+
+impl GreeterAsync for MyAsyncGreeter {
+    type Error = planus::Error;
+
+    async fn say_hello(&self, request: HelloRequestRef<'_>) -> Result<HelloReply, Self::Error> {
+        Ok(HelloReply {
+            message: format!("Hello, {}!", request.name()?.unwrap_or("world")),
+        })
+    }
+
+    async fn say_hello_again(
+        &self,
+        request: HelloRequestRef<'_>,
+    ) -> Result<HelloReply, Self::Error> {
+        self.say_hello(request).await
+    }
+}
+
 assert_eq!(<MyGreeter as Greeter>::NAME, "Greeter");
+assert_eq!(<MyAsyncGreeter as GreeterAsync>::NAME, "Greeter");
 
 let mut builder = planus::Builder::new();
 let offset = HelloRequest::create(&mut builder, "Planus");
@@ -28,3 +54,12 @@ assert_eq!(reply.message, "Hello, Planus!");
 
 let reply = MyGreeter.say_hello_again(request).unwrap();
 assert_eq!(reply.message, "Hello, Planus!");
+
+// The futures of `GreeterAsync` have no await points, so they complete on
+// the first poll and can be driven without an executor.
+let mut cx = Context::from_waker(Waker::noop());
+let mut future = pin!(MyAsyncGreeter.say_hello_again(request));
+let Poll::Ready(reply) = future.as_mut().poll(&mut cx) else {
+    panic!("future should be ready on the first poll");
+};
+assert_eq!(reply.unwrap().message, "Hello, Planus!");

--- a/test/rust-test-2021/api_files/rpc_service.rs
+++ b/test/rust-test-2021/api_files/rpc_service.rs
@@ -44,6 +44,21 @@ impl GreeterAsync for MyAsyncGreeter {
 assert_eq!(<MyGreeter as Greeter>::NAME, "Greeter");
 assert_eq!(<MyAsyncGreeter as GreeterAsync>::NAME, "Greeter");
 
+assert_eq!(
+    GreeterMethod::ENUM_VALUES,
+    [GreeterMethod::SayHello, GreeterMethod::SayHelloAgain]
+);
+assert_eq!(GreeterMethod::SayHello.id(), 0);
+assert_eq!(GreeterMethod::SayHelloAgain.id(), 1);
+assert_eq!(GreeterMethod::SayHello.name(), "SayHello");
+assert_eq!(GreeterMethod::SayHelloAgain.name(), "SayHelloAgain");
+assert_eq!(
+    GreeterMethod::try_from(0u32).unwrap(),
+    GreeterMethod::SayHello
+);
+assert_eq!(u32::from(GreeterMethod::SayHelloAgain), 1);
+assert!(GreeterMethod::try_from(2u32).is_err());
+
 let mut builder = planus::Builder::new();
 let offset = HelloRequest::create(&mut builder, "Planus");
 let data = builder.finish(offset, None);


### PR DESCRIPTION
Closes #56

## What

`rpc_service` declarations are now supported instead of being rejected with "Rpc services are not currently supported". Each service generates a **module-level name constant**, **transport-agnostic Rust traits** — a sync one and an async one — plus a **method enum with numeric ids** for routing:

```rust
/// The fully-qualified name of the `Greeter` service in the flatbuffers schema.
pub const GREETER_NAME: &str = "example.Greeter";

/// A simple greeting service.
pub trait Greeter {
    /// Also available without an implementing type as [`GREETER_NAME`].
    const NAME: &'static str = GREETER_NAME;

    /// The error type returned by the methods of this service.
    type Error;

    fn say_hello(&self, request: HelloRequestRef<'_>)
        -> Result<HelloReply, Self::Error>;
}

/// A simple greeting service.
#[allow(async_fn_in_trait)]
pub trait GreeterAsync {
    const NAME: &'static str = GREETER_NAME;
    type Error;

    async fn say_hello(&self, request: HelloRequestRef<'_>)
        -> Result<HelloReply, Self::Error>;
}

/// The methods of the rpc service `example.Greeter`.
#[repr(u32)]
pub enum GreeterMethod {
    SayHello = 0,
}

impl GreeterMethod {
    pub const SERVICE_NAME: &'static str = GREETER_NAME;
    pub const ENUM_VALUES: [Self; 1];
    pub fn id(self) -> u32;           // zero-based declaration index
    pub fn name(self) -> &'static str; // "SayHello"
}
// + TryFrom<u32> (UnknownEnumTagKind on bad ids) and From<GreeterMethod> for u32
```

Requests are received as the zero-copy `Ref` types and responses are returned as the owned types, so the traits work as server-side handler interfaces over any transport. Schema docstrings are carried through, and `idempotent` methods get a doc note. The async trait uses native async-fn-in-trait (stable since 1.75, below the 1.88 MSRV), so there are no new dependencies; the `#[allow(async_fn_in_trait)]` leaves the `Send`-bound decision to implementors. The method enum gives transports a stable numeric handle for dispatching/relaying messages without hardcoding ids; ids follow declaration order (documented on the type), mirroring the conventions of the schema-enum codegen (`ENUM_VALUES`, `TryFrom`, serde derives). The free name constant exists because an associated const on a trait cannot be read without an implementing type — clients and relays that never implement the handler traits would otherwise need a dummy probe impl just to learn the service name.

Since flatc has no Rust RPC output to stay compatible with, this deliberately starts with the smallest useful surface (no generated client/server stubs, no dependency on any specific RPC framework). Happy to adjust the design based on feedback — that's also why streaming is rejected rather than given a made-up signature.

## Changes by layer

- **planus-types / planus-translation**: `translate_rpc_service` now actually translates methods (it previously returned an empty map), `intermediate::RpcMethod` gains `idempotent` + docstrings. Argument/return types are validated to be tables (same rule as flatc). `streaming: "none"` and `idempotent` are accepted; `streaming: "client"/"server"/"bidi"` get a dedicated "not currently supported" error.
- **planus-codegen**: added `generate_rpc_service`/`generate_rpc_method` to the `Backend` trait and replaced the three `todo!()`s in `backend_translation.rs`, so services flow through the same pipeline as the other declarations.
- **Rust backend**: generates the constant, traits and method enum above, using the existing name-reservation machinery.
- **Dot backend**: services render as nodes with one row per method and edges to argument/return tables.
- **README/CHANGELOG**: `rpc_service` removed from the unsupported list (with a note that streaming methods are still unsupported).

## Tests

- `test/rust-test-20xx/api_files/rpc_service.{fbs,rs}`: implements both generated traits and does a full serialize → read-as-ref → handle → assert round-trip; the async future is driven via `Waker::noop()` so no executor dependency is needed; the name constants and the method enum's ids, names, `ENUM_VALUES` and `TryFrom` conversions are asserted.
- `test/files/valid/rpc_service.fbs`: accepted-schema fixture (namespaces, docstrings, `idempotent`, `streaming: "none"`).
- `test/files/invalid/rpc_bad_types.{fbs,stderr}` and `rpc_streaming.{fbs,stderr}`: golden stderr for non-table method types and for all streaming variants + an invalid streaming value.
- Regenerated `rpc_service_as_type.stderr` and `defined_twice.stderr`, whose expected output changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)