### PR TITLE
When running rustfmt don't error if stderr is non-empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Fixed
-- Fixed rustfmt error handling. Don't return error if rustfmt succeed but prints to stderr, just print out stderr instead.
+- Fixed rustfmt error handling. Don't return error if rustfmt succeed but prints to stderr, just print out stderr instead. [#363](https://github.com/planus-org/planus/pull/363)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Fixed
+- Fixed rustfmt error handling. Don't return error if rustfmt succeed but prints to stderr, just print out stderr instead.
 
 ### Removed
 

--- a/crates/planus-codegen/src/rust/mod.rs
+++ b/crates/planus-codegen/src/rust/mod.rs
@@ -1040,15 +1040,22 @@ pub fn format_string(s: &str, max_width: Option<u64>) -> eyre::Result<String> {
         .wait_with_output()
         .wrap_err("Unable to get the formatted file back from rustfmt")?;
 
-    if output.status.success() && output.stderr.is_empty() {
-        Ok(String::from_utf8_lossy(&output.stdout).into_owned())
-    } else if output.stderr.is_empty() {
-        eyre::bail!("rustfmt failed with exit code {}", output.status);
-    } else {
-        eyre::bail!(
+    match (output.status.success(), output.stderr.is_empty()) {
+        (true, true) => Ok(String::from_utf8_lossy(&output.stdout).into_owned()),
+        (true, false) => {
+            eprintln!("rustfmt succeeded but generated unexpected output on stderr:");
+            let error = String::from_utf8_lossy(&output.stderr);
+            for l in error.lines() {
+                eprintln!("   {l}");
+            }
+
+            Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+        }
+        (false, false) => eyre::bail!("rustfmt failed with exit code {}", output.status),
+        (false, true) => eyre::bail!(
             "rustfmt failed with exit code {} and message:\n{}",
             output.status,
             String::from_utf8_lossy(&output.stderr).into_owned(),
-        )
+        ),
     }
 }


### PR DESCRIPTION
Currently planus fails if rustfmt prints to stderr, even if the call succeeds (meaning warnings are treated as an error).
With this PR planus will print rustfmt's stderr if it's non-empty, but only fail if the call to rustfmt fails.


**Checklist**
- [ x ] Updated CHANGELOG.md with relevant changes
- [ ] Added tests for any new/fixed functionality
- [ ] Added/updated documentation for new/changed code
- [ ] Checked that README.md still makes sense (and updated it if necessary)
