### PR TITLE
Fix clippy

### DIFF
--- a/crates/planus-buffer-inspection/src/lib.rs
+++ b/crates/planus-buffer-inspection/src/lib.rs
@@ -455,10 +455,8 @@ impl VTableObject {
     ) -> Result<impl 'a + ExactSizeIterator<Item = u16> + DoubleEndedIterator> {
         let size = self.get_vtable_size(buffer)?;
         let slice: &[u8] = buffer.read_slice(self.offset, size as usize)?;
-        Ok(slice[4..].chunks_exact(2).map(move |chunk| {
-            let slice: &[u8; 2] = chunk.try_into().unwrap();
-            u16::from_le_bytes(*slice)
-        }))
+        let (chunks, _) = slice[4..].as_chunks::<2>();
+        Ok(chunks.iter().map(move |chunk| u16::from_le_bytes(*chunk)))
     }
 
     fn type_name(&self, declarations: &Declarations) -> String {

--- a/crates/planus-codegen/src/rust/mod.rs
+++ b/crates/planus-codegen/src/rust/mod.rs
@@ -173,6 +173,87 @@ fn format_relative_namespace<'a>(
     )
 }
 
+struct StructFieldType {
+    owned_type: String,
+    getter_return_type: String,
+    getter_code: String,
+    can_do_infallible_conversion: bool,
+}
+
+impl RustBackend {
+    fn struct_field_type(
+        &self,
+        resolved_type: ResolvedType<'_, Self>,
+        parent_info: &Struct,
+        name: &str,
+    ) -> StructFieldType {
+        match resolved_type {
+            ResolvedType::Struct(decl_id, _, info, relative_namespace) => {
+                let owned_type =
+                    format_relative_namespace(&relative_namespace, &info.owned_name).to_string();
+                let ref_name = format_relative_namespace(&relative_namespace, &info.ref_name);
+                StructFieldType {
+                    owned_type,
+                    getter_return_type: format!("{ref_name}<'a>"),
+                    getter_code: "::core::convert::From::from(buffer)".to_string(),
+                    can_do_infallible_conversion: self.infallible_analysis[decl_id.0],
+                }
+            }
+            ResolvedType::Enum(_, decl, info, relative_namespace, _) => {
+                let owned_type =
+                    format_relative_namespace(&relative_namespace, &info.name).to_string();
+                StructFieldType {
+                    getter_return_type: format!(
+                        "::core::result::Result<{owned_type}, ::planus::errors::UnknownEnumTag>"
+                    ),
+                    getter_code: format!(
+                        r#"let value: ::core::result::Result<{}, _> = ::core::convert::TryInto::try_into({}::from_le_bytes(*buffer.as_array()));
+                    value.map_err(|e| e.with_error_location(
+                        {:?},
+                        {:?},
+                        buffer.offset_from_start,
+                    ))"#,
+                        owned_type,
+                        integer_type(&decl.type_),
+                        parent_info.ref_name,
+                        name
+                    ),
+                    can_do_infallible_conversion: true,
+                    owned_type,
+                }
+            }
+            ResolvedType::Bool => {
+                let owned_type = "bool".to_string();
+                StructFieldType {
+                    getter_return_type: owned_type.clone(),
+                    getter_code: "buffer.as_array()[0] != 0".to_string(),
+                    can_do_infallible_conversion: true,
+                    owned_type,
+                }
+            }
+            ResolvedType::Integer(typ) => {
+                let owned_type = integer_type(&typ).to_string();
+                StructFieldType {
+                    getter_return_type: owned_type.clone(),
+                    getter_code: format!("{owned_type}::from_le_bytes(*buffer.as_array())"),
+                    can_do_infallible_conversion: true,
+                    owned_type,
+                }
+            }
+            ResolvedType::Float(typ) => {
+                let owned_type = float_type(&typ).to_string();
+                StructFieldType {
+                    getter_return_type: owned_type.clone(),
+                    getter_code: format!("{owned_type}::from_le_bytes(*buffer.as_array())"),
+                    can_do_infallible_conversion: true,
+                    owned_type,
+                }
+            }
+            _ => unreachable!(),
+        }
+    }
+}
+
 impl Backend for RustBackend {
     type NamespaceInfo = Namespace;
     type TableInfo = Table;
@@ -830,59 +911,12 @@ impl Backend for RustBackend {
             "name",
             &mut translation_context.declaration_names,
         );
-        let owned_type;
-        let getter_code;
-        let getter_return_type;
-        let can_do_infallible_conversion;
-
-        match resolved_type {
-            ResolvedType::Struct(decl_id, _, info, relative_namespace) => {
-                owned_type =
-                    format_relative_namespace(&relative_namespace, &info.owned_name).to_string();
-                let ref_name = format_relative_namespace(&relative_namespace, &info.ref_name);
-                getter_return_type = format!("{ref_name}<'a>");
-                getter_code = "::core::convert::From::from(buffer)".to_string();
-                can_do_infallible_conversion = self.infallible_analysis[decl_id.0];
-            }
-            ResolvedType::Enum(_, decl, info, relative_namespace, _) => {
-                owned_type = format_relative_namespace(&relative_namespace, &info.name).to_string();
-                getter_return_type = format!(
-                    "::core::result::Result<{owned_type}, ::planus::errors::UnknownEnumTag>"
-                );
-                getter_code = format!(
-                    r#"let value: ::core::result::Result<{}, _> = ::core::convert::TryInto::try_into({}::from_le_bytes(*buffer.as_array()));
-                    value.map_err(|e| e.with_error_location(
-                        {:?},
-                        {:?},
-                        buffer.offset_from_start,
-                    ))"#,
-                    owned_type,
-                    integer_type(&decl.type_),
-                    parent_info.ref_name,
-                    name
-                );
-                can_do_infallible_conversion = true;
-            }
-            ResolvedType::Bool => {
-                owned_type = "bool".to_string();
-                getter_return_type = owned_type.clone();
-                getter_code = "buffer.as_array()[0] != 0".to_string();
-                can_do_infallible_conversion = true;
-            }
-            ResolvedType::Integer(typ) => {
-                owned_type = integer_type(&typ).to_string();
-                getter_return_type = owned_type.clone();
-                getter_code = format!("{owned_type}::from_le_bytes(*buffer.as_array())");
-                can_do_infallible_conversion = true;
-            }
-            ResolvedType::Float(typ) => {
-                owned_type = float_type(&typ).to_string();
-                getter_return_type = owned_type.clone();
-                getter_code = format!("{owned_type}::from_le_bytes(*buffer.as_array())");
-                can_do_infallible_conversion = true;
-            }
-            _ => unreachable!(),
-        }
+        let StructFieldType {
+            owned_type,
+            getter_return_type,
+            getter_code,
+            can_do_infallible_conversion,
+        } = self.struct_field_type(resolved_type, parent_info, &name);
         StructField {
             name,
             owned_type,

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "crane": {
       "locked": {
-        "lastModified": 1772080396,
-        "narHash": "sha256-84W9UNtSk9DNMh43WBkOjpkbfODlmg+RDi854PnNgLE=",
+        "lastModified": 1783203018,
+        "narHash": "sha256-G6R9IT/xwFuu+CYBWDUAok6AdC4ERC4ZfPPFtEpxnZE=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "8525580bc0316c39dbfa18bd09a1331e98c9e463",
+        "rev": "80db5bdc391be8a1794f6d8a2d56e3a84ebcede2",
         "type": "github"
       },
       "original": {
@@ -35,16 +35,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1772047000,
-        "narHash": "sha256-7DaQVv4R97cii/Qdfy4tmDZMB2xxtyIvNGSwXBBhSmo=",
+        "lastModified": 1783389287,
+        "narHash": "sha256-0xIy4dVLqq47rA+mRy0hXDfjhQd4E5PoIns/RmB7nR4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "1267bb4920d0fc06ea916734c11b0bf004bbe17e",
+        "rev": "0ad6f47ea4fe188f4bc8f0380f93ae8523337c6c",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-25.11",
+        "ref": "nixos-26.05",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -64,11 +64,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1772334676,
-        "narHash": "sha256-Jrc0J3AH+iNJDlUze3+FJZv2R0BZnhANFnD52V4kyvI=",
+        "lastModified": 1783663825,
+        "narHash": "sha256-TTrNVoFdEw8j0Hn+shP1KAsimTmszTWBIIUliTaAuY0=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "9879be11f30fd3bbf848e653a7f991549e8973b5",
+        "rev": "072adf9b18936c1062c48123a9b77891d5968f2c",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,6 @@
 {
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-25.11";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-26.05";
     rust-overlay.url = "github:oxalica/rust-overlay";
     rust-overlay.inputs.nixpkgs.follows = "nixpkgs";
     crane.url = "github:ipetkov/crane";

--- a/test/rust-test-2021/src/hexdump.rs
+++ b/test/rust-test-2021/src/hexdump.rs
@@ -24,11 +24,9 @@ pub fn hexdump_flatbuffer_table(buf: &[u8]) -> String {
     writeln!(out, "vtable @ 0x{vtable_start:02x}..0x{vtable_end:02x}").unwrap();
 
     let mut fields = vec![(obj_end, usize::MAX)];
-    for (i, field_offset) in buf[vtable_start + 4..vtable_end]
-        .chunks_exact(2)
-        .enumerate()
-    {
-        let field_offset = u16::from_le_bytes(field_offset.try_into().unwrap()) as usize;
+    let (field_offsets, _) = buf[vtable_start + 4..vtable_end].as_chunks::<2>();
+    for (i, field_offset) in field_offsets.iter().enumerate() {
+        let field_offset = u16::from_le_bytes(*field_offset) as usize;
         if field_offset != 0 {
             fields.push((obj_start + field_offset, i));
         }


### PR DESCRIPTION
Beta clippy added a new lint (`chunks_exact_to_as_chunks`) that broke CI.

Also bumped the flake while I was at it: nixpkgs to 26.05 and rust-overlay to 1.97.0.

**Checklist**
- [x] Updated CHANGELOG.md with relevant changes
- [x] Added tests for any new/fixed functionality
- [x] Added/updated documentation for new/changed code
- [x] Checked that README.md still makes sense (and updated it if necessary)
