### PR TITLE
Fix panic when no schema files are given

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Add `--version` option to planus-cli [#364](https://github.com/planus-org/planus/pull/364)
-
 - Parse and preserve union variant metadata in the CST and formatter [#312](https://github.com/planus-org/planus/pull/312).
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fixed rustfmt error handling. Don't return error if rustfmt succeed but prints to stderr, just print out stderr instead. [#363](https://github.com/planus-org/planus/pull/363)
+- Fixed a panic when building `Declarations` from zero schemas, and made the `check`, `dot`, and `rust` CLI subcommands reject invocations with no `.fbs` files. [#371](https://github.com/planus-org/planus/pull/371)
 
 ### Removed
 

--- a/crates/planus-cli/src/app/check.rs
+++ b/crates/planus-cli/src/app/check.rs
@@ -7,7 +7,7 @@ use planus_translation::translate_files_with_options;
 /// Check validity of .fbs files
 #[derive(Parser)]
 pub struct Command {
-    #[clap(value_hint = ValueHint::FilePath)]
+    #[clap(value_hint = ValueHint::FilePath, required = true)]
     files: Vec<PathBuf>,
 }
 

--- a/crates/planus-cli/src/app/dot.rs
+++ b/crates/planus-cli/src/app/dot.rs
@@ -8,7 +8,7 @@ use planus_translation::translate_files_with_options;
 /// Generate a dot graph
 #[derive(Parser)]
 pub struct Command {
-    #[clap(value_hint = ValueHint::FilePath)]
+    #[clap(value_hint = ValueHint::FilePath, required = true)]
     files: Vec<PathBuf>,
 
     /// Output file

--- a/crates/planus-cli/src/app/rust.rs
+++ b/crates/planus-cli/src/app/rust.rs
@@ -8,7 +8,7 @@ use planus_translation::translate_files_with_options;
 /// Generate rust code
 #[derive(Parser)]
 pub struct Command {
-    #[clap(value_hint = ValueHint::FilePath)]
+    #[clap(value_hint = ValueHint::FilePath, required = true)]
     files: Vec<PathBuf>,
 
     /// Output file

--- a/crates/planus-types/src/intermediate.rs
+++ b/crates/planus-types/src/intermediate.rs
@@ -105,9 +105,10 @@ pub struct Declarations {
 
 impl Declarations {
     pub fn new(
-        namespaces: IndexMap<AbsolutePath, Namespace>,
+        mut namespaces: IndexMap<AbsolutePath, Namespace>,
         declarations: IndexMap<AbsolutePath, Declaration>,
     ) -> Self {
+        namespaces.entry(AbsolutePath::ROOT_PATH).or_default();
         let children = declarations
             .values()
             .map(|decl| match &decl.kind {


### PR DESCRIPTION
Fixes #365.

Running `planus rust -o foo` (or `check` / `dot`) with no `.fbs` file argument panicked at `planus-types` `intermediate.rs:144` on `Option::unwrap()` — the ROOT_PATH namespace was never inserted into `Declarations` because `add_schema` is what puts it there and it never ran.

Two changes:

- **`planus-types`**: `Declarations::new` now inserts a default `ROOT_PATH` namespace if the caller didn't. This restores the invariant `get_root_namespace()` relies on, so any code path that builds a `Declarations` from zero schemas gets a valid empty root instead of a panic.
- **`planus-cli`**: mark the `<FILES>...` argument on `check`, `dot`, and `rust` as `required = true` so the CLI fails fast with a clap usage error rather than silently producing an empty output file. `format` and `view` already take a single required `PathBuf` and weren't affected.

**Checklist**
- [ ] Updated CHANGELOG.md with relevant changes
- [ ] Added tests for any new/fixed functionality
- [ ] Added/updated documentation for new/changed code
- [ ] Checked that README.md still makes sense (and updated it if necessary)