### PR TITLE
Swap rustfmt failure branches to include stderr in error message

### DIFF
--- a/crates/planus-codegen/src/rust/mod.rs
+++ b/crates/planus-codegen/src/rust/mod.rs
@@ -1085,8 +1085,8 @@ pub fn format_string(s: &str, max_width: Option<u64>) -> eyre::Result<String> {
 
             Ok(String::from_utf8_lossy(&output.stdout).into_owned())
         }
-        (false, false) => eyre::bail!("rustfmt failed with exit code {}", output.status),
-        (false, true) => eyre::bail!(
+        (false, true) => eyre::bail!("rustfmt failed with exit code {}", output.status),
+        (false, false) => eyre::bail!(
             "rustfmt failed with exit code {} and message:\n{}",
             output.status,
             String::from_utf8_lossy(&output.stderr).into_owned(),


### PR DESCRIPTION
## Summary
- Follow-up to #363. The two failure arms of the `match (status.success(), stderr.is_empty())` block in `format_string` were swapped: when rustfmt exited non-zero *with* stderr content, the error dropped the message; when it exited non-zero *without* stderr, we tried to format an empty message.
- Swap the arms so the stderr message is included when it actually exists.

## Test plan
- [x] `cargo build --release --bin planus`
- [ ] No easy way to force rustfmt to exit non-zero from a planus-generated file, so this is a code-inspection fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)