### PR TITLE
Probe rustfmt with --version before piping to it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixed rustfmt error handling. Don't return error if rustfmt succeed but prints to stderr, just print out stderr instead. [#363](https://github.com/planus-org/planus/pull/363)
 - Fixed a panic when building `Declarations` from zero schemas, and made the `check`, `dot`, and `rust` CLI subcommands reject invocations with no `.fbs` files. [#371](https://github.com/planus-org/planus/pull/371)
+- Give a clear error when rustfmt is not installed instead of a confusing broken-pipe write failure. [#374](https://github.com/planus-org/planus/pull/374)
 
 ### Removed
 

--- a/crates/planus-codegen/src/rust/mod.rs
+++ b/crates/planus-codegen/src/rust/mod.rs
@@ -1046,6 +1046,20 @@ fn float_type(type_: &FloatType) -> &'static str {
 }
 
 pub fn format_string(s: &str, max_width: Option<u64>) -> eyre::Result<String> {
+    // Probe rustfmt up front so a missing binary yields a clear error.
+    let version_status = Command::new("rustfmt")
+        .arg("--version")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .wrap_err("Unable to run rustfmt. Perhaps it is not installed?")?;
+    if !version_status.success() {
+        eyre::bail!(
+            "Unable to run rustfmt (perhaps it is not installed?): `rustfmt --version` exited with {version_status}"
+        );
+    }
+
     let mut child = Command::new("rustfmt");
 
     child


### PR DESCRIPTION
Give a clear "not installed" error up front instead of relying on the subsequent spawn/write to surface a missing rustfmt. Addresses #217.

**Checklist**
- [x] Updated CHANGELOG.md with relevant changes
- [x] Added tests for any new/fixed functionality
- [x] Added/updated documentation for new/changed code
- [x] Checked that README.md still makes sense (and updated it if necessary)
