### PR TITLE
Handle flatc/flatbuffers version mismatch gracefully (#197)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,7 +2,12 @@ name: CI
 
 env:
   CARGO_TERM_COLOR: always
-  FLATBUFFER_VERSION: 24.3.25
+  # Keep in sync with `EXPECTED_FLATC_VERSION` in test/rust-test-*/build.rs, the pinned
+  # `flatbuffers` crate in test/Cargo.toml, and `flatbuffers` in flake.nix.
+  FLATBUFFER_VERSION: 25.12.19
+  # Force build.rs to hard-fail (rather than warn + skip) if the installed flatc doesn't match,
+  # so a future version drift between the crate and the CI-built flatc is caught here.
+  PLANUS_REQUIRE_FLATC: "1"
 
 on:
   push:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed rustfmt error handling. Don't return error if rustfmt succeed but prints to stderr, just print out stderr instead. [#363](https://github.com/planus-org/planus/pull/363) [#373](https://github.com/planus-org/planus/pull/373)
 - Fixed a panic when building `Declarations` from zero schemas, and made the `check`, `dot`, and `rust` CLI subcommands reject invocations with no `.fbs` files. [#371](https://github.com/planus-org/planus/pull/371)
 - Give a clear error when rustfmt is not installed instead of a confusing broken-pipe write failure. [#374](https://github.com/planus-org/planus/pull/374)
+- Skip flatc-generated tests with a warning when local `flatc` doesn't match the pinned `flatbuffers` crate, instead of failing to build. Also bumped the pin to 25.12.19. [#375](https://github.com/planus-org/planus/pull/375)
 
 ### Removed
 

--- a/test/Cargo.lock
+++ b/test/Cargo.lock
@@ -166,12 +166,6 @@ checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitflags"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
@@ -512,10 +506,10 @@ checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flatbuffers"
-version = "24.3.25"
-source = "git+https://github.com/google/flatbuffers.git?tag=v24.3.25#595bf0007ab1929570c7671f091313c8fc20644e"
+version = "25.12.19"
+source = "git+https://github.com/google/flatbuffers.git?tag=v25.12.19#7e163021e59cca4f8e1e35a7c828b5c6b7915953"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
  "rustc_version",
 ]
 
@@ -953,7 +947,7 @@ dependencies = [
 name = "planus-translation"
 version = "1.3.0"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags",
  "codespan",
  "codespan-reporting",
  "indexmap",
@@ -1107,7 +1101,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags",
 ]
 
 [[package]]

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -10,7 +10,10 @@ license = "MIT/Apache-2.0"
 [workspace.dependencies]
 color-eyre = "0.6.5"
 criterion = "0.8.2"
-flatbuffers = { version = "=24.3.25", git = "https://github.com/google/flatbuffers.git", tag = "v24.3.25" }
+# Keep this version in sync with EXPECTED_FLATC_VERSION in test/rust-test-*/build.rs and with
+# `flatbuffers` in flake.nix. `flatc` and the flatbuffers crate must match — generated Rust code
+# is version-specific.
+flatbuffers = { version = "=25.12.19", git = "https://github.com/google/flatbuffers.git", tag = "v25.12.19" }
 serde = { version = "1.0.228", default-features = false, features = [
   "derive",
   "alloc",

--- a/test/rust-test-2021/build.rs
+++ b/test/rust-test-2021/build.rs
@@ -5,12 +5,30 @@ use color_eyre::{
     Result,
 };
 
+// Keep in sync with the pinned `flatbuffers` dep in `test/Cargo.toml` and with
+// `flatbuffers` in `flake.nix`. Generated code is version-specific, so the
+// locally-installed `flatc` must match the crate we link against.
+const EXPECTED_FLATC_VERSION: &str = "25.12.19";
+
 fn main() -> Result<()> {
     color_eyre::install()?;
 
     println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-env-changed=PLANUS_SKIP_FLATC");
+    println!("cargo:rerun-if-env-changed=PLANUS_REQUIRE_FLATC");
 
     let out_dir = env::var("OUT_DIR").unwrap();
+
+    let require_flatc = env::var_os("PLANUS_REQUIRE_FLATC").is_some();
+    let flatc_available = if env::var_os("PLANUS_SKIP_FLATC").is_some() {
+        if require_flatc {
+            bail!("PLANUS_SKIP_FLATC and PLANUS_REQUIRE_FLATC are both set — pick one.",);
+        }
+        println!("cargo:warning=PLANUS_SKIP_FLATC is set; skipping flatc-generated tests.");
+        false
+    } else {
+        probe_flatc(require_flatc)?
+    };
 
     // Create API tests
     let planus_api_dir = format!("{out_dir}/planus_api");
@@ -24,7 +42,7 @@ fn main() -> Result<()> {
         "test_files",
         &planus_test_dir,
         Some(&serialize_template),
-        true,
+        flatc_available,
     )?;
 
     generate_test_code(
@@ -35,6 +53,53 @@ fn main() -> Result<()> {
     )?;
 
     Ok(())
+}
+
+// Returns `Ok(true)` when a local `flatc` matches `EXPECTED_FLATC_VERSION`. Otherwise, if
+// `require_flatc` is `false` (the default), emits a `cargo:warning=` explaining what happened
+// and returns `Ok(false)` so downstream test generation transparently falls back to the no-flatc
+// path instead of producing generated Rust that fails to compile against the pinned `flatbuffers`
+// crate. When `require_flatc` is `true` (set via `PLANUS_REQUIRE_FLATC=1` in CI), returns `Err`
+// instead so a version drift fails the build rather than silently reducing coverage.
+fn probe_flatc(require_flatc: bool) -> Result<bool> {
+    // In lax mode a probe failure becomes a `cargo:warning=` and falls back to no-flatc codegen.
+    // In strict mode (CI) the same failure aborts the build.
+    let report = |problem: String| -> Result<bool> {
+        if require_flatc {
+            bail!(
+                "{problem} PLANUS_REQUIRE_FLATC is set: install flatc {EXPECTED_FLATC_VERSION} \
+                 (see flake.nix) or unset PLANUS_REQUIRE_FLATC.",
+            )
+        } else {
+            println!(
+                "cargo:warning={problem} Skipping flatc-generated tests. Install flatc \
+                 {EXPECTED_FLATC_VERSION} (see flake.nix) or set PLANUS_SKIP_FLATC=1 to silence \
+                 this warning.",
+            );
+            Ok(false)
+        }
+    };
+
+    let output = match Command::new("flatc").arg("--version").output() {
+        Ok(output) => output,
+        Err(err) => return report(format!("Could not run `flatc --version`: {err}.")),
+    };
+    if !output.status.success() {
+        return report(format!("`flatc --version` exited with {}.", output.status));
+    }
+    // Expected output: "flatc version 25.12.19\n"
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let Some(reported) = stdout.split_whitespace().last() else {
+        return report(format!(
+            "Could not parse `flatc --version` output {stdout:?}."
+        ));
+    };
+    if reported == EXPECTED_FLATC_VERSION {
+        return Ok(true);
+    }
+    report(format!(
+        "Local flatc version {reported} does not match the expected {EXPECTED_FLATC_VERSION}.",
+    ))
 }
 
 fn generate_test_code(


### PR DESCRIPTION
Fixes #197.

The `test/` workspace runs local `flatc` against a pinned `flatbuffers`
crate; a version mismatch produces an inscrutable `E0405`.

- Bump the pinned crate to 25.12.19 (matches `flake.nix`) and
  `FLATBUFFER_VERSION` in CI to the same.
- Probe `flatc --version` in `build.rs`. On mismatch/missing: warn and
  fall back to the existing no-flatc splice. `PLANUS_SKIP_FLATC=1` to
  skip unconditionally.
- `PLANUS_REQUIRE_FLATC=1` (set in CI) turns the probe failure into a
  hard error, so future drift can't silently mask coverage.