### PR TITLE
Honor file_identifier and root_type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Parse and preserve union variant metadata in the CST and formatter [#312](https://github.com/planus-org/planus/pull/312).
 - Add `--ignore-unknown-metadata` to allow generating code from schemas that include generator-specific attributes.
 - Allow keywords as identifiers like flatc [#313](https://github.com/planus-org/planus/pull/313)
+- Honor `file_identifier`/`root_type`: generate a `IDENTIFIER` associated constant for
+  the root table and add a `planus::buffer_has_identifier` runtime helper
 
 ### Fixed
 - Fixed rustfmt error handling. Don't return error if rustfmt succeed but prints to stderr, just print out stderr instead. [#363](https://github.com/planus-org/planus/pull/363) [#373](https://github.com/planus-org/planus/pull/373)
 - Fixed a panic when building `Declarations` from zero schemas, and made the `check`, `dot`, and `rust` CLI subcommands reject invocations with no `.fbs` files. [#371](https://github.com/planus-org/planus/pull/371)
 - Give a clear error when rustfmt is not installed instead of a confusing broken-pipe write failure. [#374](https://github.com/planus-org/planus/pull/374)
 - Skip flatc-generated tests with a warning when local `flatc` doesn't match the pinned `flatbuffers` crate, instead of failing to build. Also bumped the pin to 25.12.19. [#375](https://github.com/planus-org/planus/pull/375)
+- Write the file identifier into bytes 4..8 (after the root offset) so buffers produced
+  by `Builder::finish(.., Some(id))` are byte-compatible with the official implementation
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ We support most of the base language, though some parts have not been tested in-
 Things we do not currently support:
 
 - `rpc_service`
-- `file_extension`, `file_identifier` and `root_type`
+- `file_extension`
 - Fixed-size arrays
 - Any attribute besides `required`, `deprecated`, `id` or `force_align`.
 - Some of the more exotic literal values, like hexadecimal floats or unicode surrogate pair parsing.

--- a/crates/planus-codegen/src/rust/mod.rs
+++ b/crates/planus-codegen/src/rust/mod.rs
@@ -37,6 +37,9 @@ pub struct Table {
     pub builder_name: String,
     pub should_do_default: bool,
     pub should_do_eq: bool,
+    /// The `[u8; 4]` literal for this table's file identifier, if it is a root_type
+    /// with a `file_identifier`.
+    pub file_identifier: Option<String>,
 }
 
 #[derive(Clone, Debug)]
@@ -294,7 +297,7 @@ impl Backend for RustBackend {
         _translated_namespaces: &[Self::NamespaceInfo],
         decl_id: DeclarationIndex,
         decl_name: &AbsolutePath,
-        _decl: &intermediate::Table,
+        decl: &intermediate::Table,
     ) -> Table {
         let decl_name = decl_name.0.last().unwrap();
         Table {
@@ -303,6 +306,9 @@ impl Backend for RustBackend {
             builder_name: reserve_type_name(&format!("{decl_name}Builder"), declaration_names),
             should_do_default: self.default_analysis[decl_id.0],
             should_do_eq: self.eq_analysis[decl_id.0],
+            file_identifier: decl
+                .file_identifier
+                .map(|id| format!("[{}, {}, {}, {}]", id[0], id[1], id[2], id[3])),
         }
     }
 

--- a/crates/planus-codegen/src/templates/rust/table.template
+++ b/crates/planus-codegen/src/templates/rust/table.template
@@ -27,6 +27,16 @@ impl ::core::default::Default for {{ info.owned_name }} {
 }
 {% endif %}
 
+{%- match info.file_identifier -%}
+{%- when Some(id_literal) -%}
+impl {{ info.owned_name }} {
+    /// The 4-byte file identifier for this table, declared via `file_identifier`
+    /// on the schema whose `root_type` is this table.
+    pub const IDENTIFIER: [u8; 4] = {{ id_literal }};
+}
+{%- when None -%}
+{%- endmatch %}
+
 impl {{info.owned_name}} {
     /// Creates a [{{info.builder_name}}] for serializing an instance of this table.
     #[inline]

--- a/crates/planus-translation/src/intermediate_language/translation.rs
+++ b/crates/planus-translation/src/intermediate_language/translation.rs
@@ -22,6 +22,16 @@ pub struct Translator<'a> {
     declarations: IndexMap<AbsolutePath, Declaration>,
     namespaces: IndexMap<AbsolutePath, Namespace>,
     descriptions: Vec<TypeDescription>,
+    /// `(file_identifier)` declarations, resolved against their `root_type` in `finish`.
+    file_identifiers: Vec<FileIdentifier>,
+}
+
+/// A schema-level `file_identifier` together with the `root_type` it attaches to.
+struct FileIdentifier {
+    namespace: AbsolutePath,
+    file_id: FileId,
+    root_type: Option<(Span, ast::Type)>,
+    identifier: [u8; 4],
 }
 
 #[derive(Clone)]
@@ -60,6 +70,7 @@ impl<'a> Translator<'a> {
             declarations: Default::default(),
             descriptions: Default::default(),
             namespaces: Default::default(),
+            file_identifiers: Default::default(),
         }
     }
 
@@ -128,6 +139,22 @@ impl<'a> Translator<'a> {
                 ast::TypeDeclarationKind::Union(_) => TypeDescription::Union,
                 ast::TypeDeclarationKind::RpcService(_) => TypeDescription::RpcService,
             })
+        }
+
+        if let Some((_, lit)) = &schema.file_identifier {
+            match <[u8; 4]>::try_from(lit.value.as_bytes()) {
+                Ok(identifier) => self.file_identifiers.push(FileIdentifier {
+                    namespace: namespace_path.clone(),
+                    file_id: schema.file_id,
+                    root_type: schema.root_type.clone(),
+                    identifier,
+                }),
+                Err(_) => self.ctx.emit_error(
+                    ErrorKind::MISC_SEMANTIC_ERROR,
+                    [Label::primary(schema.file_id, lit.span)],
+                    Some("file_identifier must be exactly 4 bytes"),
+                ),
+            }
         }
 
         while let Some(last) = namespace_path.pop() {
@@ -1160,6 +1187,8 @@ impl<'a> Translator<'a> {
             max_size: u32::MAX,
             max_vtable_size,
             max_alignment: u32::MAX,
+            // Filled in by `finish` once `root_type`/`file_identifier` are resolved.
+            file_identifier: None,
         }
     }
 
@@ -1565,6 +1594,39 @@ impl<'a> Translator<'a> {
             assert!(parents.is_empty());
         }
         self.resolve_table_sizes();
+
+        // Attach each schema-level file_identifier to the table named by its root_type.
+        // A file_identifier without a root_type has nothing to attach to and is ignored,
+        // matching flatc.
+        for fi in std::mem::take(&mut self.file_identifiers) {
+            let Some((_, root_type)) = &fi.root_type else {
+                continue;
+            };
+            let ast::TypeKind::Path(path) = &root_type.kind else {
+                self.ctx.emit_error(
+                    ErrorKind::TYPE_ERROR,
+                    [Label::primary(fi.file_id, root_type.span)],
+                    Some("root_type must name a table"),
+                );
+                continue;
+            };
+            match self.lookup_path(&fi.namespace, fi.file_id, path) {
+                Some(TypeKind::Table(idx)) => {
+                    if let Some((_, decl)) = self.declarations.get_index_mut(idx.0) {
+                        if let DeclarationKind::Table(table) = &mut decl.kind {
+                            table.file_identifier = Some(fi.identifier);
+                        }
+                    }
+                }
+                Some(_) => self.ctx.emit_error(
+                    ErrorKind::TYPE_ERROR,
+                    [Label::primary(fi.file_id, root_type.span)],
+                    Some("root_type must name a table"),
+                ),
+                // lookup_path already emitted an error for an unresolved path.
+                None => {}
+            }
+        }
 
         Declarations::new(self.namespaces, self.declarations)
     }

--- a/crates/planus-types/src/intermediate.rs
+++ b/crates/planus-types/src/intermediate.rs
@@ -250,6 +250,8 @@ pub struct Table {
     pub max_size: u32,
     pub max_vtable_size: u32,
     pub max_alignment: u32,
+    /// The 4-byte file identifier this table is the `root_type` for, if any.
+    pub file_identifier: Option<[u8; 4]>,
 }
 
 #[derive(Debug)]

--- a/crates/planus/src/builder.rs
+++ b/crates/planus/src/builder.rs
@@ -258,13 +258,16 @@ impl Builder {
         let root = root.prepare(self);
 
         if let Some(file_identifier) = file_identifier {
-            // TODO: how does alignment interact with file identifiers? Is the alignment with out without the header?
+            // The 8-byte header [root offset | file identifier] is aligned to the
+            // root's alignment so the root table that follows stays aligned. The
+            // builder prepends, so the identifier is written first to land in
+            // bytes 4..8, leaving the root offset at bytes 0..4 (matching flatc).
             let offset = self.prepare_write(
                 8,
                 <Offset<T> as Primitive>::ALIGNMENT_MASK.max(self.alignment_mask),
             ) as u32;
-            self.write(&(offset - 4 - root.offset).to_le_bytes());
             self.write(&file_identifier);
+            self.write(&(offset - root.offset).to_le_bytes());
         } else {
             let offset = self.prepare_write(
                 4,

--- a/crates/planus/src/lib.rs
+++ b/crates/planus/src/lib.rs
@@ -58,6 +58,15 @@ pub type Result<T> = core::result::Result<T, Error>;
 #[doc(hidden)]
 pub type Cursor<'a, const N: usize> = array_init_cursor::Cursor<'a, u8, N>;
 
+/// Returns `true` if `buffer` carries the given 4-byte file identifier.
+///
+/// FlatBuffers stores an optional file identifier in bytes 4..8, immediately
+/// after the root table offset. This checks for its presence, matching the
+/// identifier written by [`Builder::finish`] when given `Some(identifier)`.
+pub fn buffer_has_identifier(buffer: &[u8], identifier: [u8; 4]) -> bool {
+    buffer.len() >= 8 && buffer[4..8] == identifier
+}
+
 #[doc(hidden)]
 pub enum Void {}
 

--- a/test/files/invalid/docstrings_file_identifier.stderr
+++ b/test/files/invalid/docstrings_file_identifier.stderr
@@ -58,3 +58,9 @@ error: Inner doc comments are not meaningful here.
 11 │ //! Bad10
    │ ^^^^^^^^^
 
+error: file_identifier must be exactly 4 bytes
+  ┌─ test/files/invalid/docstrings_file_identifier.fbs:7:1
+  │
+7 │ "foo" /// Bad6
+  │ ^^^^^
+

--- a/test/rust-test-2021/api_files/file_identifier.fbs
+++ b/test/rust-test-2021/api_files/file_identifier.fbs
@@ -1,0 +1,10 @@
+// An 8-byte-aligned root (contains a double) so the identifier-with-alignment
+// path is exercised.
+table Message {
+  x: double;
+  n: uint64;
+  tag: ubyte;
+}
+
+root_type Message;
+file_identifier "MSG1";

--- a/test/rust-test-2021/api_files/file_identifier.rs
+++ b/test/rust-test-2021/api_files/file_identifier.rs
@@ -1,0 +1,18 @@
+use planus::ReadAsRoot;
+
+// The schema's file_identifier is exposed as an associated constant.
+assert_eq!(Message::IDENTIFIER, *b"MSG1");
+
+let mut builder = planus::Builder::new();
+let message = Message::builder().x(2.5).n(42).tag(7).finish(&mut builder);
+let bytes = builder.finish(message, Some(Message::IDENTIFIER)).to_vec();
+
+// The identifier is written into bytes 4..8, matching the flatbuffers wire format.
+assert_eq!(&bytes[4..8], b"MSG1");
+assert!(planus::buffer_has_identifier(&bytes, Message::IDENTIFIER));
+assert!(!planus::buffer_has_identifier(&bytes, *b"XXXX"));
+
+let read = MessageRef::read_as_root(&bytes).unwrap();
+assert_eq!(read.x().unwrap(), 2.5);
+assert_eq!(read.n().unwrap(), 42);
+assert_eq!(read.tag().unwrap(), 7);


### PR DESCRIPTION
A schema's file_identifier is attached to its root_type table and exposed as an IDENTIFIER associated constant, alongside a new planus::buffer_has_identifier helper. Builder::finish is also fixed to write the identifier into bytes 4..8 after the root offset (the two were previously swapped, on an untested path) so identifier-bearing buffers match the official implementation.

Addresses #141 and #55

Split out of [!366](https://github.com/planus-org/planus/pull/366)

**Checklist**
- [x] Updated CHANGELOG.md with relevant changes
- [x] Added tests for any new/fixed functionality
- [x] Added/updated documentation for new/changed code
- [x] Checked that README.md still makes sense (and updated it if necessary)
