### PR TITLE
Implement bit_flags enums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Parse and preserve union variant metadata in the CST and formatter [#312](https://github.com/planus-org/planus/pull/312).
 - Add `--ignore-unknown-metadata` to allow generating code from schemas that include generator-specific attributes.
 - Allow keywords as identifiers like flatc [#313](https://github.com/planus-org/planus/pull/313)
+- Add support for `(bit_flags)` enums, generated as a dependency-free flags newtype
 
 ### Fixed
 - Fixed rustfmt error handling. Don't return error if rustfmt succeed but prints to stderr, just print out stderr instead. [#363](https://github.com/planus-org/planus/pull/363) [#373](https://github.com/planus-org/planus/pull/373)

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Things we do not currently support:
 - `rpc_service`
 - `file_extension`, `file_identifier` and `root_type`
 - Fixed-size arrays
-- Any attribute besides `required`, `deprecated`, `id` or `force_align`.
+- Any attribute besides `required`, `deprecated`, `id`, `force_align` or `bit_flags`.
 - Some of the more exotic literal values, like hexadecimal floats or unicode surrogate pair parsing.
 
 Things we will probably never support:

--- a/crates/planus-buffer-inspection/src/object_info.rs
+++ b/crates/planus-buffer-inspection/src/object_info.rs
@@ -261,7 +261,25 @@ impl<'a> ObjectName<'a> for EnumObject {
         if let DeclarationKind::Enum(e) = &decl.kind {
             let tag = tag.read(buffer).unwrap();
             let path = path.0.last().unwrap();
-            if let Some(variant) = e.variants.get(&tag) {
+            if e.is_bit_flags {
+                let mut value = tag.to_u64();
+                let mut parts = Vec::new();
+                for (flag, variant) in &e.variants {
+                    let flag = flag.to_u64();
+                    if flag != 0 && value & flag == flag {
+                        parts.push(format!("{path}::{}", variant.name));
+                        value &= !flag;
+                    }
+                }
+                if value != 0 {
+                    parts.push(format!("{path}::UnknownBits({value:#x})"));
+                }
+                if parts.is_empty() {
+                    format!("{path}::empty")
+                } else {
+                    parts.join(" | ")
+                }
+            } else if let Some(variant) = e.variants.get(&tag) {
                 format!("{path}::{}", variant.name)
             } else {
                 format!("{path}::UnknownTag({tag})")

--- a/crates/planus-codegen/src/rust/analysis.rs
+++ b/crates/planus-codegen/src/rust/analysis.rs
@@ -186,9 +186,8 @@ impl DeclarationAnalysis for EqAnalysis {
 
 fn infallible_conversion_simple_type(infallible_conversion: &[bool], type_: &SimpleType) -> bool {
     match type_ {
-        SimpleType::Struct(decl_id) => infallible_conversion[decl_id.0],
+        SimpleType::Struct(decl_id) | SimpleType::Enum(decl_id) => infallible_conversion[decl_id.0],
         SimpleType::Bool | SimpleType::Integer(_) | SimpleType::Float(_) => true,
-        SimpleType::Enum(_) => false,
     }
 }
 
@@ -213,11 +212,11 @@ impl DeclarationAnalysis for InfallibleConversionAnalysis {
         _decl_id: DeclarationIndex,
         declaration: &Declaration,
     ) -> Self::State {
-        match declaration.kind {
+        match &declaration.kind {
             DeclarationKind::Struct(_) | DeclarationKind::Union(_) => true,
-            DeclarationKind::Enum(_)
-            | DeclarationKind::Table(_)
-            | DeclarationKind::RpcService(_) => false,
+            // A bit_flags enum reads infallibly: any integer is a valid set of flags.
+            DeclarationKind::Enum(decl) => decl.is_bit_flags,
+            DeclarationKind::Table(_) | DeclarationKind::RpcService(_) => false,
         }
     }
 
@@ -251,9 +250,13 @@ impl DeclarationAnalysis for InfallibleConversionAnalysis {
                     }
                 }
             }
-            DeclarationKind::Table(_)
-            | DeclarationKind::Enum(_)
-            | DeclarationKind::RpcService(_) => {
+            // A bit_flags enum reads infallibly; a plain enum can fail with UnknownEnumTag.
+            DeclarationKind::Enum(decl) => {
+                if !decl.is_bit_flags {
+                    cur_conversion_possible = false;
+                }
+            }
+            DeclarationKind::Table(_) | DeclarationKind::RpcService(_) => {
                 cur_conversion_possible = false;
             }
         }

--- a/crates/planus-codegen/src/rust/mod.rs
+++ b/crates/planus-codegen/src/rust/mod.rs
@@ -81,6 +81,7 @@ pub struct StructField {
 pub struct Enum {
     pub name: String,
     pub repr_type: String,
+    pub is_bit_flags: bool,
 }
 
 #[derive(Clone, Debug)]
@@ -202,24 +203,37 @@ impl RustBackend {
             ResolvedType::Enum(_, decl, info, relative_namespace, _) => {
                 let owned_type =
                     format_relative_namespace(&relative_namespace, &info.name).to_string();
-                StructFieldType {
-                    getter_return_type: format!(
-                        "::core::result::Result<{owned_type}, ::planus::errors::UnknownEnumTag>"
-                    ),
-                    getter_code: format!(
-                        r#"let value: ::core::result::Result<{}, _> = ::core::convert::TryInto::try_into({}::from_le_bytes(*buffer.as_array()));
+                if decl.is_bit_flags {
+                    // Any integer is a valid set of flags, so reading is infallible.
+                    StructFieldType {
+                        getter_return_type: owned_type.clone(),
+                        getter_code: format!(
+                            "{owned_type}({}::from_le_bytes(*buffer.as_array()))",
+                            integer_type(&decl.type_),
+                        ),
+                        can_do_infallible_conversion: true,
+                        owned_type,
+                    }
+                } else {
+                    StructFieldType {
+                        getter_return_type: format!(
+                            "::core::result::Result<{owned_type}, ::planus::errors::UnknownEnumTag>"
+                        ),
+                        getter_code: format!(
+                            r#"let value: ::core::result::Result<{}, _> = ::core::convert::TryInto::try_into({}::from_le_bytes(*buffer.as_array()));
                     value.map_err(|e| e.with_error_location(
                         {:?},
                         {:?},
                         buffer.offset_from_start,
                     ))"#,
+                            owned_type,
+                            integer_type(&decl.type_),
+                            parent_info.ref_name,
+                            name
+                        ),
+                        can_do_infallible_conversion: true,
                         owned_type,
-                        integer_type(&decl.type_),
-                        parent_info.ref_name,
-                        name
-                    ),
-                    can_do_infallible_conversion: true,
-                    owned_type,
+                    }
                 }
             }
             ResolvedType::Bool => {
@@ -336,6 +350,7 @@ impl Backend for RustBackend {
         Enum {
             name: reserve_type_name(decl_name, declaration_names),
             repr_type: format!("{:?}", decl.type_).to_lowercase(),
+            is_bit_flags: decl.is_bit_flags,
         }
     }
 
@@ -566,6 +581,16 @@ impl Backend for RustBackend {
                         );
                         deserialize_default = Some(impl_default_code.clone());
                     }
+                    // bit_flags fields carry a numeric default (the empty set, or an
+                    // explicit flag combination) rather than a single named variant.
+                    AssignMode::HasDefault(Literal::Int(lit)) => {
+                        read_type = vtable_type.clone();
+                        owned_type = vtable_type.clone();
+                        create_trait = format!("WriteAsDefault<{owned_type}, {owned_type}>");
+                        impl_default_code = format!("{owned_type}({lit})").into();
+                        serialize_default = Some(format!("&{owned_type}({lit})").into());
+                        deserialize_default = Some(impl_default_code.clone());
+                    }
                     AssignMode::Optional => {
                         read_type = format!("::core::option::Option<{vtable_type}>");
                         owned_type = read_type.clone();
@@ -655,6 +680,10 @@ impl Backend for RustBackend {
                             "::planus::Vector<'a, ::planus::Result<{}<'a>>>",
                             format_relative_namespace(relative_namespace, &info.ref_name)
                         ),
+                        ResolvedType::Enum(_, decl, info, relative_namespace, _) if decl.is_bit_flags => format!(
+                            "::planus::Vector<'a, {}>",
+                            format_relative_namespace(relative_namespace, &info.name)
+                        ),
                         ResolvedType::Enum(_, _, info, relative_namespace, _) => format!(
                             "::planus::Vector<'a, ::core::result::Result<{}, ::planus::errors::UnknownEnumTag>>",
                             format_relative_namespace(relative_namespace, &info.name)
@@ -689,6 +718,8 @@ impl Backend for RustBackend {
                 }
                 fn vector_try_into_func(type_: &ResolvedType<'_, RustBackend>) -> &'static str {
                     match type_ {
+                        // bit_flags enums read infallibly, like plain integers.
+                        ResolvedType::Enum(_, decl, ..) if decl.is_bit_flags => "to_vec",
                         ResolvedType::Table(..)
                         | ResolvedType::Enum(..)
                         | ResolvedType::Vector(..)

--- a/crates/planus-codegen/src/templates/rust/enum.template
+++ b/crates/planus-codegen/src/templates/rust/enum.template
@@ -1,3 +1,235 @@
+{%- if info.is_bit_flags -%}
+{% for docstring in docstrings.iter_strings() %}
+/// {{ docstring }}
+{%- endfor %}
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default, ::serde::Serialize, ::serde::Deserialize)]
+#[repr(transparent)]
+pub struct {{ info.name }}(pub {{ info.repr_type }});
+
+#[allow(non_upper_case_globals)]
+impl {{ info.name }} {
+    {% for variant in variants -%}
+        {% for docstring in variant.name_and_docs.docstrings.iter_strings() %}
+        /// {{ docstring }}
+        {%- endfor %}
+        pub const {{ variant.name }}: {{ info.name }} = {{ info.name }}({{ variant.value }});
+    {% endfor %}
+
+    /// The empty set of flags.
+    pub const fn empty() -> Self {
+        Self(0)
+    }
+
+    /// The set of all defined flags.
+    pub const fn all() -> Self {
+        Self(0 {%- for variant in variants %} | Self::{{ variant.name }}.0 {%- endfor %})
+    }
+
+    /// The raw underlying integer value.
+    pub const fn bits(&self) -> {{ info.repr_type }} {
+        self.0
+    }
+
+    /// Returns `true` if no flags are set.
+    pub const fn is_empty(&self) -> bool {
+        self.0 == 0
+    }
+
+    /// Returns `true` if all of the flags in `other` are set in `self`.
+    pub const fn contains(&self, other: Self) -> bool {
+        (self.0 & other.0) == other.0
+    }
+
+    /// Returns `true` if any of the flags in `other` are set in `self`.
+    pub const fn intersects(&self, other: Self) -> bool {
+        (self.0 & other.0) != 0
+    }
+}
+
+impl ::core::convert::From<{{ info.repr_type }}> for {{ info.name }} {
+    #[inline]
+    fn from(value: {{ info.repr_type }}) -> Self {
+        Self(value)
+    }
+}
+
+impl ::core::convert::From<{{ info.name }}> for {{ info.repr_type }} {
+    #[inline]
+    fn from(value: {{ info.name }}) -> Self {
+        value.0
+    }
+}
+
+impl ::core::ops::BitOr for {{ info.name }} {
+    type Output = Self;
+    #[inline]
+    fn bitor(self, other: Self) -> Self {
+        Self(self.0 | other.0)
+    }
+}
+
+impl ::core::ops::BitOrAssign for {{ info.name }} {
+    #[inline]
+    fn bitor_assign(&mut self, other: Self) {
+        self.0 |= other.0;
+    }
+}
+
+impl ::core::ops::BitAnd for {{ info.name }} {
+    type Output = Self;
+    #[inline]
+    fn bitand(self, other: Self) -> Self {
+        Self(self.0 & other.0)
+    }
+}
+
+impl ::core::ops::BitAndAssign for {{ info.name }} {
+    #[inline]
+    fn bitand_assign(&mut self, other: Self) {
+        self.0 &= other.0;
+    }
+}
+
+impl ::core::ops::BitXor for {{ info.name }} {
+    type Output = Self;
+    #[inline]
+    fn bitxor(self, other: Self) -> Self {
+        Self(self.0 ^ other.0)
+    }
+}
+
+impl ::core::ops::BitXorAssign for {{ info.name }} {
+    #[inline]
+    fn bitxor_assign(&mut self, other: Self) {
+        self.0 ^= other.0;
+    }
+}
+
+impl ::core::ops::Not for {{ info.name }} {
+    type Output = Self;
+    #[inline]
+    fn not(self) -> Self {
+        Self(!self.0 & Self::all().0)
+    }
+}
+
+impl ::core::fmt::Debug for {{ info.name }} {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+        let mut first = true;
+        f.write_str("{{ info.name }}(")?;
+        {% for variant in variants -%}
+        if self.contains({{ info.name }}::{{ variant.name }}) {
+            if !first {
+                f.write_str(" | ")?;
+            }
+            first = false;
+            f.write_str("{{ variant.name }}")?;
+        }
+        {% endfor -%}
+        let _ = first;
+        f.write_str(")")
+    }
+}
+
+/// # Safety
+/// The Planus compiler correctly calculates `ALIGNMENT` and `SIZE`.
+unsafe impl ::planus::Primitive for {{ info.name }} {
+    const ALIGNMENT: usize = {{ size }};
+    const SIZE: usize = {{ size }};
+}
+
+impl ::planus::WriteAsPrimitive<{{ info.name }}> for {{ info.name }} {
+    #[inline]
+    fn write<const N: usize>(&self, cursor: ::planus::Cursor<'_, N>, buffer_position: u32) {
+        self.0.write(cursor, buffer_position);
+    }
+}
+
+impl ::planus::WriteAs<{{ info.name }}> for {{ info.name }} {
+    type Prepared = Self;
+
+    #[inline]
+    fn prepare(&self, _builder: &mut ::planus::Builder) -> {{ info.name }} {
+        *self
+    }
+}
+
+impl ::planus::WriteAsDefault<{{ info.name }}, {{ info.name }}> for {{ info.name }} {
+    type Prepared = Self;
+
+    #[inline]
+    fn prepare(&self, _builder: &mut ::planus::Builder, default: &{{ info.name }}) -> ::core::option::Option<{{ info.name }}> {
+        if self == default {
+            ::core::option::Option::None
+        } else {
+            ::core::option::Option::Some(*self)
+        }
+    }
+}
+
+impl ::planus::WriteAsOptional<{{ info.name }}> for {{ info.name }} {
+    type Prepared = Self;
+
+    #[inline]
+    fn prepare(&self, _builder: &mut ::planus::Builder) -> ::core::option::Option<{{ info.name }}> {
+        ::core::option::Option::Some(*self)
+    }
+}
+
+impl<'buf> ::planus::TableRead<'buf> for {{ info.name }} {
+    #[inline]
+    fn from_buffer(buffer: ::planus::SliceWithStartOffset<'buf>, offset: usize) -> ::core::result::Result<Self, ::planus::errors::ErrorKind> {
+        let n: {{ info.repr_type }} = ::planus::TableRead::from_buffer(buffer, offset)?;
+        ::core::result::Result::Ok(Self(n))
+    }
+}
+
+impl<'buf> ::planus::VectorRead<'buf> for {{ info.name }} {
+    const STRIDE: usize = {{ size }};
+    #[inline]
+    unsafe fn from_buffer(buffer: ::planus::SliceWithStartOffset<'buf>, offset: usize) -> Self {
+        {%- if info.repr_type == "u8" -%}
+        Self(unsafe { *buffer.buffer.get_unchecked(offset) })
+        {%- else -%}
+        Self(unsafe { <{{ info.repr_type }} as ::planus::VectorRead>::from_buffer(buffer, offset) })
+        {%- endif -%}
+    }
+}
+
+/// # Safety
+/// The planus compiler generates implementations that initialize
+/// the bytes in `write_values`.
+unsafe impl ::planus::VectorWrite<{{ info.name }}> for {{ info.name }} {
+    const STRIDE: usize = {{ size }};
+
+    type Value = Self;
+
+    #[inline]
+    fn prepare(&self, _builder: &mut ::planus::Builder) -> Self {
+        *self
+    }
+
+    #[inline]
+    unsafe fn write_values(
+        values: &[Self],
+        bytes: *mut ::core::mem::MaybeUninit<u8>,
+        buffer_position: u32,
+    ) {
+        let bytes = bytes as *mut [::core::mem::MaybeUninit<u8>; {{ size }}];
+        for (i, v) in ::core::iter::Iterator::enumerate(values.iter()) {
+            ::planus::WriteAsPrimitive::write(
+                v,
+                ::planus::Cursor::new(unsafe { &mut *bytes.add(i) }),
+                {% if size == 1 %}
+                buffer_position - i as u32,
+                {% else %}
+                buffer_position - ({{ size }} * i) as u32,
+                {% endif %}
+            );
+        }
+    }
+}
+{%- else -%}
 {% for docstring in docstrings.iter_strings() %}
 /// {{ docstring }}
 {%- endfor %}
@@ -153,3 +385,4 @@ unsafe impl ::planus::VectorWrite<{{info.name}}> for {{ info.name }} {
         }
     }
 }
+{%- endif -%}

--- a/crates/planus-translation/src/intermediate_language/translation.rs
+++ b/crates/planus-translation/src/intermediate_language/translation.rs
@@ -1165,33 +1165,85 @@ impl<'a> Translator<'a> {
 
     fn translate_enum(&self, current_file_id: FileId, decl: &ast::Enum) -> Enum {
         let alignment = decl.type_.byte_size();
+        let mut is_bit_flags = false;
+        let mut bit_flags_span = None;
         for m in &decl.metadata.values {
-            self.emit_metadata_support_error(
-                current_file_id,
-                m,
-                "enums",
-                m.kind.accepted_on_enums(),
+            match m.kind {
+                MetadataValueKind::BitFlags => {
+                    is_bit_flags = true;
+                    bit_flags_span = Some(m.span);
+                }
+                _ => {
+                    self.emit_metadata_support_error(
+                        current_file_id,
+                        m,
+                        "enums",
+                        m.kind.accepted_on_enums(),
+                    );
+                }
+            }
+        }
+
+        if is_bit_flags && !decl.type_.is_unsigned() {
+            self.ctx.emit_error(
+                ErrorKind::TYPE_ERROR,
+                [Label::primary(current_file_id, bit_flags_span.unwrap())
+                    .with_message("the underlying type of a bit_flags enum must be unsigned")],
+                Some(&format!("{} is signed", decl.type_.flatbuffer_name())),
             );
         }
 
         let mut variants: IndexMap<IntegerLiteral, EnumVariant> = IndexMap::new();
         let mut next_value = IntegerLiteral::default_value_from_type(&decl.type_);
+        let mut next_position = 0u32;
         for (ident, variant) in decl.variants.iter() {
-            let mut value = next_value;
             let name = self.ctx.resolve_identifier(*ident);
-            if let Some(assignment) = &variant.value {
-                if let Some(v) = self.translate_integer(
-                    current_file_id,
-                    assignment.span,
-                    assignment.is_negative,
-                    &assignment.value,
-                    &decl.type_,
-                ) {
-                    value = v;
+            // For bit_flags enums each member's literal is a bit *position*, and its
+            // stored value is `1 << position`; for plain enums the literal is the value.
+            let value = if is_bit_flags {
+                let position = if let Some(assignment) = &variant.value {
+                    match self.translate_integer(
+                        current_file_id,
+                        assignment.span,
+                        assignment.is_negative,
+                        &assignment.value,
+                        &decl.type_,
+                    ) {
+                        Some(v) => v.to_u64() as u32,
+                        None => continue,
+                    }
                 } else {
+                    next_position
+                };
+                let Some(value) = IntegerLiteral::from_bit_position(&decl.type_, position) else {
+                    self.ctx.emit_error(
+                        ErrorKind::NUMERICAL_RANGE_ERROR,
+                        [Label::primary(current_file_id, variant.span)
+                            .with_message("bit flag is out of range of the underlying type")],
+                        None,
+                    );
                     continue;
                 };
-            }
+                next_position = position + 1;
+                value
+            } else {
+                let mut value = next_value;
+                if let Some(assignment) = &variant.value {
+                    if let Some(v) = self.translate_integer(
+                        current_file_id,
+                        assignment.span,
+                        assignment.is_negative,
+                        &assignment.value,
+                        &decl.type_,
+                    ) {
+                        value = v;
+                    } else {
+                        continue;
+                    };
+                }
+                next_value = value.next();
+                value
+            };
             match variants.entry(value) {
                 Entry::Occupied(entry) => {
                     self.ctx.emit_error(
@@ -1215,12 +1267,12 @@ impl<'a> Translator<'a> {
                     });
                 }
             }
-            next_value = value.next();
         }
         Enum {
             variants,
             type_: decl.type_,
             alignment,
+            is_bit_flags,
         }
     }
 
@@ -1604,17 +1656,25 @@ impl<'a> Translator<'a> {
 
     pub fn default_value_for_enum(&self, declaration_index: DeclarationIndex) -> Option<Literal> {
         match &self.descriptions[declaration_index.0] {
-            TypeDescription::Enum(decl) => decl
-                .variants
-                .iter()
-                .enumerate()
-                .filter_map(|(variant_index, (k, _v))| {
-                    (k.is_zero()).then_some(Literal::EnumTag {
-                        variant_index,
-                        value: *k,
+            TypeDescription::Enum(decl) => {
+                // A bit_flags field always defaults to the empty set (0), even though
+                // 0 is not a named variant.
+                if decl.is_bit_flags {
+                    return Some(Literal::Int(IntegerLiteral::default_value_from_type(
+                        &decl.type_,
+                    )));
+                }
+                decl.variants
+                    .iter()
+                    .enumerate()
+                    .filter_map(|(variant_index, (k, _v))| {
+                        (k.is_zero()).then_some(Literal::EnumTag {
+                            variant_index,
+                            value: *k,
+                        })
                     })
-                })
-                .next(),
+                    .next()
+            }
             _ => unreachable!(),
         }
     }

--- a/crates/planus-types/src/ast.rs
+++ b/crates/planus-types/src/ast.rs
@@ -493,6 +493,10 @@ impl IntegerType {
         }
     }
 
+    pub fn is_unsigned(&self) -> bool {
+        matches!(self, Self::U8 | Self::U16 | Self::U32 | Self::U64)
+    }
+
     pub fn flatbuffer_name(&self) -> &'static str {
         match self {
             IntegerType::U8 => "uint8",

--- a/crates/planus-types/src/intermediate.rs
+++ b/crates/planus-types/src/intermediate.rs
@@ -316,6 +316,7 @@ pub struct Enum {
     pub type_: IntegerType,
     pub variants: IndexMap<IntegerLiteral, EnumVariant>,
     pub alignment: u32,
+    pub is_bit_flags: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -609,6 +610,26 @@ impl IntegerLiteral {
             crate::ast::IntegerType::I32 => Self::I32(0),
             crate::ast::IntegerType::I64 => Self::I64(0),
         }
+    }
+
+    /// Returns `1 << position` as a literal of the given integer type, used to
+    /// turn a `(bit_flags)` enum member's bit position into its stored value.
+    /// Returns `None` when `position` is out of range for the type's bit width.
+    pub fn from_bit_position(type_: &crate::ast::IntegerType, position: u32) -> Option<Self> {
+        use crate::ast::IntegerType;
+        if position >= type_.byte_size() * 8 {
+            return None;
+        }
+        Some(match type_ {
+            IntegerType::U8 => Self::U8(1 << position),
+            IntegerType::U16 => Self::U16(1 << position),
+            IntegerType::U32 => Self::U32(1 << position),
+            IntegerType::U64 => Self::U64(1 << position),
+            IntegerType::I8 => Self::I8(1 << position),
+            IntegerType::I16 => Self::I16(1 << position),
+            IntegerType::I32 => Self::I32(1 << position),
+            IntegerType::I64 => Self::I64(1 << position),
+        })
     }
 
     #[must_use]

--- a/test/rust-test-2021/api_files/bit_flags_enum.fbs
+++ b/test/rust-test-2021/api_files/bit_flags_enum.fbs
@@ -1,0 +1,12 @@
+enum Fault : uint16 (bit_flags) {
+  A,
+  B,
+  C = 10,
+}
+
+table Holder {
+  flags: Fault;
+  list: [Fault];
+}
+
+root_type Holder;

--- a/test/rust-test-2021/api_files/bit_flags_enum.rs
+++ b/test/rust-test-2021/api_files/bit_flags_enum.rs
@@ -1,0 +1,37 @@
+use planus::ReadAsRoot;
+
+// Member values are bit positions: value == 1 << position (matching flatc).
+assert_eq!(Fault::A.0, 1);
+assert_eq!(Fault::B.0, 2);
+assert_eq!(Fault::C.0, 1024);
+
+assert_eq!(Fault::empty().0, 0);
+assert_eq!(Fault::all().0, 1 | 2 | 1024);
+assert!(Fault::empty().is_empty());
+
+let combo = Fault::A | Fault::C;
+assert_eq!(combo.0, 1025);
+assert!(combo.contains(Fault::A));
+assert!(!combo.contains(Fault::B));
+assert!(combo.intersects(Fault::C));
+assert!(!combo.intersects(Fault::B));
+
+// `!` masks back to the known bits.
+assert_eq!((!Fault::A).0, 1026);
+
+// Infallible conversions to/from the underlying integer.
+assert_eq!(Fault::from(2u16), Fault::B);
+assert_eq!(u16::from(Fault::C), 1024u16);
+
+// Round-trip through a buffer as a scalar field and a vector element.
+let mut builder = planus::Builder::new();
+let holder = Holder::builder()
+    .flags(combo)
+    .list(vec![Fault::B, Fault::C])
+    .finish(&mut builder);
+let bytes = builder.finish(holder, None).to_vec();
+
+let read = HolderRef::read_as_root(&bytes).unwrap();
+assert_eq!(read.flags().unwrap(), combo);
+let list: Vec<Fault> = read.list().unwrap().unwrap().to_vec().unwrap();
+assert_eq!(list, vec![Fault::B, Fault::C]);


### PR DESCRIPTION
Accept the (bit_flags) attribute on enums (unsigned underlying type, member value = 1 << position) and generate a dependency-free #[repr(transparent)] newtype with flag constants, bitwise operators and a decomposing Debug. Reads are infallible, so bit_flags enums flow through codegen like their underlying integer.

I guess this counts as an "exotic" type, which is now supported. The official rust library implements this with a crate dependency, but it seemed like that wouldn't be in-line with planus's goals.

Split out of [!366](https://github.com/planus-org/planus/pull/366)

**Checklist**
- [x] Updated CHANGELOG.md with relevant changes
- [x] Added tests for any new/fixed functionality
- [x] Added/updated documentation for new/changed code
- [x] Checked that README.md still makes sense (and updated it if necessary)
